### PR TITLE
add error handling

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -5,17 +5,18 @@ pub use file_adapter::FileAdapter;
 pub use memory_adapter::MemoryAdapter;
 
 use crate::model::Model;
+use crate::Result;
 
 pub trait Adapter {
-    fn load_policy(&self, m: &mut Model);
-    fn save_policy(&self, m: &mut Model);
-    fn add_policy(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> bool;
-    fn remove_policy(&self, sec: &str, ptype: &str, rule: Vec<&str>) -> bool;
+    fn load_policy(&self, m: &mut Model) -> Result<()>;
+    fn save_policy(&self, m: &mut Model) -> Result<()>;
+    fn add_policy(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool>;
+    fn remove_policy(&self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool>;
     fn remove_filtered_policy(
         &self,
         sec: &str,
         ptype: &str,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> bool;
+    ) -> Result<bool>;
 }

--- a/src/adapter/memory_adapter.rs
+++ b/src/adapter/memory_adapter.rs
@@ -1,5 +1,6 @@
 use crate::adapter::Adapter;
 use crate::model::Model;
+use crate::Result;
 
 use std::collections::HashSet;
 
@@ -9,7 +10,7 @@ pub struct MemoryAdapter {
 }
 
 impl Adapter for MemoryAdapter {
-    fn load_policy(&self, m: &mut Model) {
+    fn load_policy(&self, m: &mut Model) -> Result<()> {
         for line in self.policy.iter() {
             let sec = line[0].clone();
             let ptype = line[1].clone();
@@ -20,23 +21,24 @@ impl Adapter for MemoryAdapter {
                 }
             }
         }
+        Ok(())
     }
 
-    fn save_policy(&self, _m: &mut Model) {
+    fn save_policy(&self, _m: &mut Model) -> Result<()> {
         unimplemented!();
     }
 
-    fn add_policy(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> bool {
+    fn add_policy(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool> {
         let mut line: Vec<String> = rule.into_iter().map(String::from).collect();
         line.insert(0, ptype.to_owned());
         line.insert(0, sec.to_owned());
         if self.policy.insert(line) {
-            return true;
+            return Ok(true);
         }
-        false
+        Ok(false)
     }
 
-    fn remove_policy(&self, _sec: &str, _ptype: &str, _rule: Vec<&str>) -> bool {
+    fn remove_policy(&self, _sec: &str, _ptype: &str, _rule: Vec<&str>) -> Result<bool> {
         unimplemented!();
     }
 
@@ -46,7 +48,7 @@ impl Adapter for MemoryAdapter {
         _ptype: &str,
         _field_index: usize,
         _field_values: Vec<&str>,
-    ) -> bool {
+    ) -> Result<bool> {
         unimplemented!();
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,21 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+#[derive(Debug, Clone)]
+pub struct CasbinError {
+    msg: &'static str,
+}
+
+impl CasbinError {
+    pub fn new(msg: &'static str) -> Self {
+        CasbinError { msg }
+    }
+}
+
+impl Display for CasbinError {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "casbin error, msg={}", self.msg)
+    }
+}
+
+impl Error for CasbinError {}

--- a/src/internal_api.rs
+++ b/src/internal_api.rs
@@ -1,39 +1,40 @@
 use crate::adapter::Adapter;
 use crate::enforcer::Enforcer;
+use crate::Result;
 
 pub trait InternalApi {
-    fn add_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> bool;
-    fn remove_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> bool;
+    fn add_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool>;
+    fn remove_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool>;
     fn remove_filtered_policy_internal(
         &mut self,
         sec: &str,
         ptype: &str,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> bool;
+    ) -> Result<bool>;
 }
 
 impl<A: Adapter> InternalApi for Enforcer<A> {
-    fn add_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> bool {
+    fn add_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool> {
         let rule_added = self.model.add_policy(sec, ptype, rule.clone());
         if !rule_added {
-            return false;
+            return Ok(false);
         }
         if self.auto_save {
             return self.adapter.add_policy(sec, ptype, rule.clone());
         }
-        rule_added
+        Ok(rule_added)
     }
 
-    fn remove_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> bool {
+    fn remove_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool> {
         let rule_removed = self.model.remove_policy(sec, ptype, rule.clone());
         if !rule_removed {
-            return false;
+            return Ok(false);
         }
         if self.auto_save {
-            self.adapter.remove_policy(sec, ptype, rule.clone());
+            return self.adapter.remove_policy(sec, ptype, rule.clone());
         }
-        rule_removed
+        Ok(rule_removed)
     }
 
     fn remove_filtered_policy_internal(
@@ -42,12 +43,12 @@ impl<A: Adapter> InternalApi for Enforcer<A> {
         ptype: &str,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> bool {
+    ) -> Result<bool> {
         let rule_removed =
             self.model
                 .remove_filtered_policy(sec, ptype, field_index, field_values.clone());
         if !rule_removed {
-            return false;
+            return Ok(false);
         }
         if self.auto_save {
             return self.adapter.remove_filtered_policy(
@@ -57,6 +58,6 @@ impl<A: Adapter> InternalApi for Enforcer<A> {
                 field_values.clone(),
             );
         }
-        rule_removed
+        Ok(rule_removed)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod adapter;
 pub mod config;
 pub mod effector;
 pub mod enforcer;
+pub mod errors;
 pub mod internal_api;
 pub mod management_api;
 pub mod model;
@@ -11,3 +12,5 @@ mod rbac_api;
 pub use internal_api::InternalApi;
 pub use management_api::MgmtApi;
 pub use rbac_api::RbacApi;
+
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

--- a/src/management_api.rs
+++ b/src/management_api.rs
@@ -1,78 +1,83 @@
 use crate::adapter::Adapter;
 use crate::enforcer::Enforcer;
 use crate::InternalApi;
+use crate::Result;
 
 pub trait MgmtApi {
-    fn add_policy(&mut self, params: Vec<&str>) -> bool;
-    fn remove_policy(&mut self, params: Vec<&str>) -> bool;
-    fn add_named_policy(&mut self, ptype: &str, params: Vec<&str>) -> bool;
-    fn remove_named_policy(&mut self, ptype: &str, params: Vec<&str>) -> bool;
-    fn add_grouping_policy(&mut self, params: Vec<&str>) -> bool;
-    fn remove_grouping_policy(&mut self, params: Vec<&str>) -> bool;
-    fn add_named_grouping_policy(&mut self, ptype: &str, params: Vec<&str>) -> bool;
-    fn remove_named_grouping_policy(&mut self, ptype: &str, params: Vec<&str>) -> bool;
-    fn remove_filtered_policy(&mut self, field_index: usize, field_values: Vec<&str>) -> bool;
+    fn add_policy(&mut self, params: Vec<&str>) -> Result<bool>;
+    fn remove_policy(&mut self, params: Vec<&str>) -> Result<bool>;
+    fn add_named_policy(&mut self, ptype: &str, params: Vec<&str>) -> Result<bool>;
+    fn remove_named_policy(&mut self, ptype: &str, params: Vec<&str>) -> Result<bool>;
+    fn add_grouping_policy(&mut self, params: Vec<&str>) -> Result<bool>;
+    fn remove_grouping_policy(&mut self, params: Vec<&str>) -> Result<bool>;
+    fn add_named_grouping_policy(&mut self, ptype: &str, params: Vec<&str>) -> Result<bool>;
+    fn remove_named_grouping_policy(&mut self, ptype: &str, params: Vec<&str>) -> Result<bool>;
+    fn remove_filtered_policy(
+        &mut self,
+        field_index: usize,
+        field_values: Vec<&str>,
+    ) -> Result<bool>;
     fn remove_filtered_grouping_policy(
         &mut self,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> bool;
+    ) -> Result<bool>;
     fn remove_filtered_named_policy(
         &mut self,
         ptype: &str,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> bool;
+    ) -> Result<bool>;
     fn remove_filtered_named_grouping_policy(
         &mut self,
         ptype: &str,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> bool;
+    ) -> Result<bool>;
 }
 
 impl<A: Adapter> MgmtApi for Enforcer<A> {
-    fn add_policy(&mut self, params: Vec<&str>) -> bool {
+    fn add_policy(&mut self, params: Vec<&str>) -> Result<bool> {
         self.add_named_policy("p", params)
     }
 
-    fn remove_policy(&mut self, params: Vec<&str>) -> bool {
+    fn remove_policy(&mut self, params: Vec<&str>) -> Result<bool> {
         self.remove_named_policy("p", params)
     }
 
-    fn add_named_policy(&mut self, ptype: &str, params: Vec<&str>) -> bool {
+    fn add_named_policy(&mut self, ptype: &str, params: Vec<&str>) -> Result<bool> {
         self.add_policy_internal("p", ptype, params)
     }
 
-    fn remove_named_policy(&mut self, ptype: &str, params: Vec<&str>) -> bool {
+    fn remove_named_policy(&mut self, ptype: &str, params: Vec<&str>) -> Result<bool> {
         self.remove_policy_internal("p", ptype, params)
     }
 
-    fn add_grouping_policy(&mut self, params: Vec<&str>) -> bool {
+    fn add_grouping_policy(&mut self, params: Vec<&str>) -> Result<bool> {
         self.add_named_grouping_policy("g", params)
     }
 
-    fn add_named_grouping_policy(&mut self, ptype: &str, params: Vec<&str>) -> bool {
-        let rule_added = self.add_policy_internal("g", ptype, params);
+    fn add_named_grouping_policy(&mut self, ptype: &str, params: Vec<&str>) -> Result<bool> {
+        let rule_added = self.add_policy_internal("g", ptype, params)?;
         self.build_role_links();
-        rule_added
+        Ok(rule_added)
     }
 
-    fn remove_grouping_policy(&mut self, params: Vec<&str>) -> bool {
+    fn remove_grouping_policy(&mut self, params: Vec<&str>) -> Result<bool> {
         self.remove_named_grouping_policy("g", params)
     }
 
-    fn remove_named_grouping_policy(&mut self, ptype: &str, params: Vec<&str>) -> bool {
-        let rule_removed = self.remove_policy_internal("g", ptype, params);
+    fn remove_named_grouping_policy(&mut self, ptype: &str, params: Vec<&str>) -> Result<bool> {
+        let rule_removed = self.remove_policy_internal("g", ptype, params)?;
         self.build_role_links();
-        rule_removed
+        Ok(rule_removed)
     }
 
     fn remove_filtered_grouping_policy(
         &mut self,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> bool {
+    ) -> Result<bool> {
         self.remove_filtered_named_grouping_policy("g", field_index, field_values)
     }
 
@@ -81,14 +86,18 @@ impl<A: Adapter> MgmtApi for Enforcer<A> {
         ptype: &str,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> bool {
+    ) -> Result<bool> {
         let rule_removed =
-            self.remove_filtered_policy_internal("g", ptype, field_index, field_values);
+            self.remove_filtered_policy_internal("g", ptype, field_index, field_values)?;
         self.build_role_links();
-        rule_removed
+        Ok(rule_removed)
     }
 
-    fn remove_filtered_policy(&mut self, field_index: usize, field_values: Vec<&str>) -> bool {
+    fn remove_filtered_policy(
+        &mut self,
+        field_index: usize,
+        field_values: Vec<&str>,
+    ) -> Result<bool> {
         self.remove_filtered_named_policy("p", field_index, field_values)
     }
 
@@ -97,7 +106,7 @@ impl<A: Adapter> MgmtApi for Enforcer<A> {
         ptype: &str,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> bool {
+    ) -> Result<bool> {
         self.remove_filtered_policy_internal("p", ptype, field_index, field_values)
     }
 }


### PR DESCRIPTION
`Adapter` is easy to generate error, because of error propagating, `model` and `enforcer` that used those adapter methods must return an error.

I actually don't like this commit because of those annoying `Results`, what do you think? @GopherJ @hsluoyz 