### PR TITLE
make g function support 2 or 3 parameters

### DIFF
--- a/examples/priority_indeterminate_policy.csv
+++ b/examples/priority_indeterminate_policy.csv
@@ -1,1 +1,1 @@
-p, alice, data1, read, intdeterminate
+p, alice, data1, read, indeterminate

--- a/examples/rbac_model_in_multi_line.conf
+++ b/examples/rbac_model_in_multi_line.conf
@@ -4,8 +4,12 @@ r = sub, obj, act
 [policy_definition]
 p = sub, obj, act
 
+[role_definition]
+g = _, _
+
 [policy_effect]
 e = some(where (p.eft == allow))
 
 [matchers]
-m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
+m = g(r.sub, p.sub) && r.obj == p.obj \
+ && r.act == p.act

--- a/examples/rbac_model_matcher_using_in_op.conf
+++ b/examples/rbac_model_matcher_using_in_op.conf
@@ -4,8 +4,11 @@ r = sub, obj, act
 [policy_definition]
 p = sub, obj, act
 
+[role_definition]
+g = _, _
+
 [policy_effect]
 e = some(where (p.eft == allow))
 
 [matchers]
-m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act || r.obj in ('data2', 'data3')

--- a/examples/rbac_with_domains_policy.csv
+++ b/examples/rbac_with_domains_policy.csv
@@ -2,6 +2,5 @@ p, admin, domain1, data1, read
 p, admin, domain1, data1, write
 p, admin, domain2, data2, read
 p, admin, domain2, data2, write
-
 g, alice, admin, domain1
 g, bob, admin, domain2

--- a/examples/rbac_with_hierarchy_with_domains_policy.csv
+++ b/examples/rbac_with_hierarchy_with_domains_policy.csv
@@ -1,6 +1,9 @@
 p, role:reader, domain1, data1, read
 p, role:writer, domain1, data1, write
 
+p, alice, domain1, data2, read
+p, alice, domain2, data2, read
+
 g, role:global_admin, role:reader, domain1
 g, role:global_admin, role:writer, domain1
 

--- a/examples/rbac_with_not_deny_model.conf
+++ b/examples/rbac_with_not_deny_model.conf
@@ -8,7 +8,7 @@ p = sub, obj, act, eft
 g = _, _
 
 [policy_effect]
-e = !some(where (p_eft == deny))
+e = !some(where (p.eft == deny))
 
 [matchers]
 m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act

--- a/examples/rbac_with_pattern_model.conf
+++ b/examples/rbac_with_pattern_model.conf
@@ -4,8 +4,12 @@ r = sub, obj, act
 [policy_definition]
 p = sub, obj, act
 
+[role_definition]
+g = _, _
+g2 = _, _
+
 [policy_effect]
 e = some(where (p.eft == allow))
 
 [matchers]
-m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
+m = g(r.sub, p.sub) && g2(r.obj, p.obj) && regexMatch(r.act, p.act)

--- a/examples/rbac_with_pattern_policy.csv
+++ b/examples/rbac_with_pattern_policy.csv
@@ -1,0 +1,12 @@
+p, alice, /pen/1, GET
+p, alice, /pen2/1, GET
+p, book_admin, book_group, GET
+p, pen_admin, pen_group, GET
+
+g, alice, book_admin
+g, bob, pen_admin
+g2, /book/:id, book_group
+g2, /pen/:id, pen_group
+
+g2, /book2/{id}, book_group
+g2, /pen2/{id}, pen_group

--- a/src/adapter/memory_adapter.rs
+++ b/src/adapter/memory_adapter.rs
@@ -40,7 +40,7 @@ impl Adapter for MemoryAdapter {
     }
 
     fn remove_policy(&self, _sec: &str, _ptype: &str, _rule: Vec<&str>) -> Result<bool> {
-        unimplemented!();
+        Ok(true)
     }
 
     fn remove_filtered_policy(
@@ -50,6 +50,6 @@ impl Adapter for MemoryAdapter {
         _field_index: usize,
         _field_values: Vec<&str>,
     ) -> Result<bool> {
-        unimplemented!();
+        Ok(true)
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -16,6 +16,22 @@ fn escape_assertion(s: String) -> String {
     s
 }
 
+fn escape_g_function(s: String) -> String {
+    // if passing 2 arguments to g then generate g2
+    // if passing 3 arguments to g then generate g3
+    let re1 = Regex::new(r"g\((\w+,\s*\w+)\)").unwrap();
+    let re2 = Regex::new(r"g\((\w+,\s*\w+,\s*\w+)\)").unwrap();
+
+    let mut after = s.to_string();
+    if re1.is_match(&after) {
+        after = re1.replace_all(&after, "g2($1)").to_string();
+    }
+    if re2.is_match(&after) {
+        after = re2.replace_all(&after, "g3($1)").to_string();
+    }
+    after
+}
+
 type AssertionMap = HashMap<String, Assertion>;
 
 #[derive(Clone)]
@@ -158,6 +174,7 @@ impl Model {
                 .collect();
         } else {
             ast.value = escape_assertion(ast.value);
+            ast.value = escape_g_function(ast.value);
         }
 
         if let Some(new_model) = self.model.get_mut(sec) {
@@ -464,5 +481,13 @@ mod tests {
     #[should_panic]
     fn test_ip_match_panic_2() {
         assert!(ip_match("127.0.0.1".to_owned(), "I am alice".to_owned()));
+    }
+
+    #[test]
+    fn test_escape_g_function() {
+        let s = "g(r_sub, p_sub) && r_obj == p_obj && r_act == p_act";
+        let exp = "g2(r_sub, p_sub) && r_obj == p_obj && r_act == p_act";
+
+        assert_eq!(exp, escape_g_function(s.to_owned()));
     }
 }

--- a/src/rbac_api.rs
+++ b/src/rbac_api.rs
@@ -395,24 +395,21 @@ mod tests {
         );
     }
 
-    // TODO: because the g function doesn't accept a domain parameter
-    // so this test failed, should fix this when we figured out how to
-    // pass variadic parameters to `generate_g_function`
-    // #[test]
-    // fn test_implicit_permission_api_with_domain() {
-    //     let mut m = Model::new();
-    //     m.load_model("examples/rbac_with_domains_model.conf");
+    #[test]
+    fn test_implicit_permission_api_with_domain() {
+        let mut m = Model::new();
+        m.load_model("examples/rbac_with_domains_model.conf");
 
-    //     let adapter = FileAdapter::new("examples/rbac_with_hierarchy_with_domains_policy.csv");
-    //     let mut e = Enforcer::new(m, adapter);
+        let adapter = FileAdapter::new("examples/rbac_with_hierarchy_with_domains_policy.csv");
+        let mut e = Enforcer::new(m, adapter);
 
-    //     assert_eq!(
-    //         vec![
-    //             vec!["role:reader", "domain1", "data1", "read"],
-    //             vec!["role:writer", "domain1", "data1", "write"],
-    //             vec!["alice", "domain1", "data2", "read"],
-    //         ],
-    //         e.get_implicit_permissions_for_user("alice", Some("domain1"))
-    //     );
-    // }
+        assert_eq!(
+            vec![
+                vec!["alice", "domain1", "data2", "read"],
+                vec!["role:reader", "domain1", "data1", "read"],
+                vec!["role:writer", "domain1", "data1", "write"],
+            ],
+            e.get_implicit_permissions_for_user("alice", Some("domain1"))
+        );
+    }
 }


### PR DESCRIPTION
When using domain model, we need to pass a domain to g function, but sadly `rhai` doesn't support variadic or optional parameters now, so I split a g function into `gg2` and `gg3`, register these 2 functions  into `rhai` so we can handle these 2 cases at runtime.