### PR TITLE
Add multi-thread support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-regex = "1"
-rhai = "0.7"
+regex = "1.3.1"
+rhai = "0.9.1"
 ip_network = "0.3.4"

--- a/src/effector.rs
+++ b/src/effector.rs
@@ -1,4 +1,4 @@
-pub trait Effector {
+pub trait Effector: Send + Sync {
     fn merge_effects(&self, expr: String, effects: Vec<EffectKind>, results: Vec<f64>) -> bool;
 }
 

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -5,7 +5,7 @@ use crate::model::{load_function_map, FunctionMap};
 use crate::rbac::{DefaultRoleManager, RoleManager};
 use crate::Result;
 
-use rhai::{Engine, FnRegister, Scope};
+use rhai::{Engine, RegisterFn, Scope};
 
 pub trait MatchFnClone2: Fn(String, String) -> bool {
     fn clone_box(&self) -> Box<dyn MatchFnClone2>;

--- a/src/model.rs
+++ b/src/model.rs
@@ -22,7 +22,7 @@ fn escape_g_function(s: String) -> String {
     let re1 = Regex::new(r"g\((\w+,\s*\w+)\)").unwrap();
     let re2 = Regex::new(r"g\((\w+,\s*\w+,\s*\w+)\)").unwrap();
 
-    let mut after = s.to_string();
+    let mut after = s;
     if re1.is_match(&after) {
         after = re1.replace_all(&after, "gg2($1)").to_string();
     }

--- a/src/rbac/role_manager.rs
+++ b/src/rbac/role_manager.rs
@@ -1,6 +1,6 @@
 use crate::Result;
 
-pub trait RoleManager {
+pub trait RoleManager: Send + Sync {
     fn clone_box(&self) -> Box<dyn RoleManager>;
     fn clear(&mut self);
     fn add_link(&mut self, name1: &str, name2: &str, domain: Option<&str>);


### PR DESCRIPTION
The original version uses `Rc`, `RefCell` and `HashMap` which are not shareable between threads.

This commit replaced `Rc` with `Arc`, `RefCell` with `RwLock` and manually deal with locks with `read().unwrap()` and `write().unwrap()`, a simple test `test_role_api_threads` shows how to operate casbin in a thread and then sync to other threads.