### PR TITLE
remove Send & Sync marker to make it easier to construct error types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,4 @@ pub use management_api::MgmtApi;
 pub use model::Model;
 pub use rbac_api::RbacApi;
 
-pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;


### PR DESCRIPTION
While developing diesel-adapter, I'm having problems creating an error type to be able to be shared/transferred across threads.

I tried:

```rust
unsafe impl Send for MyError {}
unsafe impl Sync for MyError {}
```

but it still cannot work, I would like to release a first version of `diesel-adapter`, can we just remove these two markers at the very early stage and add them in the future?