### PR TITLE
Optimize error handling

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -4,19 +4,20 @@ pub mod memory_adapter;
 pub use file_adapter::FileAdapter;
 pub use memory_adapter::MemoryAdapter;
 
+use crate::errors::RuntimeError;
 use crate::model::Model;
-use crate::Result;
 
 pub trait Adapter {
-    fn load_policy(&self, m: &mut Model) -> Result<()>;
-    fn save_policy(&self, m: &mut Model) -> Result<()>;
-    fn add_policy(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool>;
-    fn remove_policy(&self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool>;
+    fn load_policy(&self, m: &mut Model) -> Result<(), RuntimeError>;
+    fn save_policy(&self, m: &mut Model) -> Result<(), RuntimeError>;
+    fn add_policy(&mut self, sec: &str, ptype: &str, rule: Vec<&str>)
+        -> Result<bool, RuntimeError>;
+    fn remove_policy(&self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool, RuntimeError>;
     fn remove_filtered_policy(
         &self,
         sec: &str,
         ptype: &str,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> Result<bool>;
+    ) -> Result<bool, RuntimeError>;
 }

--- a/src/adapter/memory_adapter.rs
+++ b/src/adapter/memory_adapter.rs
@@ -1,6 +1,6 @@
 use crate::adapter::Adapter;
+use crate::errors::RuntimeError;
 use crate::model::Model;
-use crate::Result;
 
 use std::collections::HashSet;
 
@@ -10,7 +10,7 @@ pub struct MemoryAdapter {
 }
 
 impl Adapter for MemoryAdapter {
-    fn load_policy(&self, m: &mut Model) -> Result<()> {
+    fn load_policy(&self, m: &mut Model) -> Result<(), RuntimeError> {
         for line in self.policy.iter() {
             let sec = line[0].clone();
             let ptype = line[1].clone();
@@ -25,11 +25,16 @@ impl Adapter for MemoryAdapter {
         Ok(())
     }
 
-    fn save_policy(&self, _m: &mut Model) -> Result<()> {
+    fn save_policy(&self, _m: &mut Model) -> Result<(), RuntimeError> {
         unimplemented!();
     }
 
-    fn add_policy(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool> {
+    fn add_policy(
+        &mut self,
+        sec: &str,
+        ptype: &str,
+        rule: Vec<&str>,
+    ) -> Result<bool, RuntimeError> {
         let mut line: Vec<String> = rule.into_iter().map(String::from).collect();
         line.insert(0, ptype.to_owned());
         line.insert(0, sec.to_owned());
@@ -39,7 +44,12 @@ impl Adapter for MemoryAdapter {
         Ok(false)
     }
 
-    fn remove_policy(&self, _sec: &str, _ptype: &str, _rule: Vec<&str>) -> Result<bool> {
+    fn remove_policy(
+        &self,
+        _sec: &str,
+        _ptype: &str,
+        _rule: Vec<&str>,
+    ) -> Result<bool, RuntimeError> {
         Ok(true)
     }
 
@@ -49,7 +59,7 @@ impl Adapter for MemoryAdapter {
         _ptype: &str,
         _field_index: usize,
         _field_values: Vec<&str>,
-    ) -> Result<bool> {
+    ) -> Result<bool, RuntimeError> {
         Ok(true)
     }
 }

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -1,9 +1,9 @@
 use crate::adapter::Adapter;
 use crate::effector::{DefaultEffector, EffectKind, Effector};
+use crate::errors::RuntimeError;
 use crate::model::Model;
 use crate::model::{load_function_map, FunctionMap};
 use crate::rbac::{DefaultRoleManager, RoleManager};
-use crate::Result;
 
 use rhai::{Engine, RegisterFn, Scope};
 
@@ -292,13 +292,13 @@ impl<A: Adapter> Enforcer<A> {
         self.eft.merge_effects(ee, policy_effects, vec![])
     }
 
-    pub fn build_role_links(&mut self) -> Result<()> {
+    pub fn build_role_links(&mut self) -> Result<(), RuntimeError> {
         self.rm.clear();
         self.model.build_role_links(&mut self.rm)?;
         Ok(())
     }
 
-    pub fn load_policy(&mut self) -> Result<()> {
+    pub fn load_policy(&mut self) -> Result<(), RuntimeError> {
         self.model.clear_policy();
         self.adapter.load_policy(&mut self.model)?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,20 +2,63 @@ use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Debug, Clone)]
-pub struct CasbinError {
-    msg: &'static str,
+pub enum ParseError {
+    RoleDefinitionNumber,
+    GroupingPolicyNumber,
+    DomainLength,
 }
 
-impl CasbinError {
-    pub fn new(msg: &'static str) -> Self {
-        CasbinError { msg }
-    }
-}
+impl Error for ParseError {}
 
-impl Display for CasbinError {
+impl Display for ParseError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(f, "casbin error, msg={}", self.msg)
+        let description = match self {
+            ParseError::RoleDefinitionNumber => {
+                String::from("the number of \"_\" in role definition should be at least 2")
+            }
+            ParseError::GroupingPolicyNumber => {
+                String::from("grouping policy elements do not meet role definition")
+            }
+            ParseError::DomainLength => String::from("domain can at most contains 1 string"),
+        };
+        write!(f, "{}", description)
     }
 }
 
-impl Error for CasbinError {}
+#[derive(Debug)]
+pub enum RuntimeError {
+    IoError(String),
+    ParseError(ParseError),
+    AdapterError(String), // for third-party adapters
+    RoleNotExists,
+    PolicyFilePathEmpty,
+}
+
+impl Error for RuntimeError {}
+
+impl Display for RuntimeError {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let description = match self {
+            RuntimeError::RoleNotExists => String::from("name1 or name2 doesn't exists"),
+            RuntimeError::PolicyFilePathEmpty => {
+                String::from("save policy failed, file path is empty")
+            }
+            RuntimeError::IoError(s) => s.to_owned(),
+            RuntimeError::ParseError(s) => s.to_string(),
+            RuntimeError::AdapterError(s) => s.to_owned(),
+        };
+        write!(f, "{}", description)
+    }
+}
+
+impl From<std::io::Error> for RuntimeError {
+    fn from(error: std::io::Error) -> Self {
+        RuntimeError::IoError(error.to_string())
+    }
+}
+
+impl From<ParseError> for RuntimeError {
+    fn from(error: ParseError) -> Self {
+        RuntimeError::ParseError(error)
+    }
+}

--- a/src/internal_api.rs
+++ b/src/internal_api.rs
@@ -1,21 +1,36 @@
 use crate::adapter::Adapter;
 use crate::enforcer::Enforcer;
-use crate::Result;
+use crate::errors::RuntimeError;
 
 pub trait InternalApi {
-    fn add_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool>;
-    fn remove_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool>;
+    fn add_policy_internal(
+        &mut self,
+        sec: &str,
+        ptype: &str,
+        rule: Vec<&str>,
+    ) -> Result<bool, RuntimeError>;
+    fn remove_policy_internal(
+        &mut self,
+        sec: &str,
+        ptype: &str,
+        rule: Vec<&str>,
+    ) -> Result<bool, RuntimeError>;
     fn remove_filtered_policy_internal(
         &mut self,
         sec: &str,
         ptype: &str,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> Result<bool>;
+    ) -> Result<bool, RuntimeError>;
 }
 
 impl<A: Adapter> InternalApi for Enforcer<A> {
-    fn add_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool> {
+    fn add_policy_internal(
+        &mut self,
+        sec: &str,
+        ptype: &str,
+        rule: Vec<&str>,
+    ) -> Result<bool, RuntimeError> {
         let rule_added = self.model.add_policy(sec, ptype, rule.clone());
         if !rule_added {
             return Ok(false);
@@ -26,7 +41,12 @@ impl<A: Adapter> InternalApi for Enforcer<A> {
         Ok(rule_added)
     }
 
-    fn remove_policy_internal(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool> {
+    fn remove_policy_internal(
+        &mut self,
+        sec: &str,
+        ptype: &str,
+        rule: Vec<&str>,
+    ) -> Result<bool, RuntimeError> {
         let rule_removed = self.model.remove_policy(sec, ptype, rule.clone());
         if !rule_removed {
             return Ok(false);
@@ -43,7 +63,7 @@ impl<A: Adapter> InternalApi for Enforcer<A> {
         ptype: &str,
         field_index: usize,
         field_values: Vec<&str>,
-    ) -> Result<bool> {
+    ) -> Result<bool, RuntimeError> {
         let rule_removed =
             self.model
                 .remove_filtered_policy(sec, ptype, field_index, field_values.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,3 @@ pub use internal_api::InternalApi;
 pub use management_api::MgmtApi;
 pub use model::Model;
 pub use rbac_api::RbacApi;
-
-pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/src/rbac/default_role_manager.rs
+++ b/src/rbac/default_role_manager.rs
@@ -1,6 +1,5 @@
-use crate::errors::CasbinError;
+use crate::errors::RuntimeError;
 use crate::rbac::RoleManager;
-use crate::Result;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -55,7 +54,12 @@ impl RoleManager for DefaultRoleManager {
         role1.write().unwrap().add_role(role2);
     }
 
-    fn delete_link(&mut self, name1: &str, name2: &str, domain: Option<&str>) -> Result<()> {
+    fn delete_link(
+        &mut self,
+        name1: &str,
+        name2: &str,
+        domain: Option<&str>,
+    ) -> Result<(), RuntimeError> {
         let mut name1 = name1.to_owned();
         let mut name2 = name2.to_owned();
         if let Some(domain_val) = domain {
@@ -63,7 +67,7 @@ impl RoleManager for DefaultRoleManager {
             name2 = format!("{}::{}", domain_val, name2);
         }
         if !self.has_role(&name1) || !self.has_role(&name2) {
-            return Err(CasbinError::new("name1 or name2 doesn't exists").into());
+            return Err(RuntimeError::RoleNotExists);
         }
         let role1 = self.create_role(&name1);
         let role2 = self.create_role(&name2);

--- a/src/rbac/role_manager.rs
+++ b/src/rbac/role_manager.rs
@@ -1,10 +1,15 @@
-use crate::Result;
+use crate::errors::RuntimeError;
 
 pub trait RoleManager: Send + Sync {
     fn clone_box(&self) -> Box<dyn RoleManager>;
     fn clear(&mut self);
     fn add_link(&mut self, name1: &str, name2: &str, domain: Option<&str>);
-    fn delete_link(&mut self, name1: &str, name2: &str, domain: Option<&str>) -> Result<()>;
+    fn delete_link(
+        &mut self,
+        name1: &str,
+        name2: &str,
+        domain: Option<&str>,
+    ) -> Result<(), RuntimeError>;
     fn has_link(&mut self, name1: &str, name2: &str, domain: Option<&str>) -> bool;
     fn get_roles(&mut self, name: &str, domain: Option<&str>) -> Vec<String>;
     fn get_users(&self, name: &str, domain: Option<&str>) -> Vec<String>;

--- a/src/rbac_api.rs
+++ b/src/rbac_api.rs
@@ -1,22 +1,30 @@
 use crate::adapter::Adapter;
 use crate::enforcer::Enforcer;
+use crate::errors::RuntimeError;
 use crate::MgmtApi;
-use crate::Result;
 use std::collections::HashMap;
 
 pub trait RbacApi {
-    fn add_permission_for_user(&mut self, user: &str, permission: Vec<&str>) -> Result<bool>;
-    fn add_role_for_user(&mut self, user: &str, role: &str) -> Result<bool>;
-    fn delete_role_for_user(&mut self, user: &str, role: &str) -> Result<bool>;
-    fn delete_roles_for_user(&mut self, user: &str) -> Result<bool>;
+    fn add_permission_for_user(
+        &mut self,
+        user: &str,
+        permission: Vec<&str>,
+    ) -> Result<bool, RuntimeError>;
+    fn add_role_for_user(&mut self, user: &str, role: &str) -> Result<bool, RuntimeError>;
+    fn delete_role_for_user(&mut self, user: &str, role: &str) -> Result<bool, RuntimeError>;
+    fn delete_roles_for_user(&mut self, user: &str) -> Result<bool, RuntimeError>;
     fn get_roles_for_user(&mut self, name: &str) -> Vec<String>;
     fn get_users_for_role(&self, name: &str) -> Vec<String>;
     fn has_role_for_user(&mut self, name: &str, role: &str) -> bool;
-    fn delete_user(&mut self, name: &str) -> Result<bool>;
-    fn delete_role(&mut self, name: &str) -> Result<bool>;
-    fn delete_permission(&mut self, permission: Vec<&str>) -> Result<bool>;
-    fn delete_permission_for_user(&mut self, user: &str, permission: Vec<&str>) -> Result<bool>;
-    fn delete_permissions_for_user(&mut self, user: &str) -> Result<bool>;
+    fn delete_user(&mut self, name: &str) -> Result<bool, RuntimeError>;
+    fn delete_role(&mut self, name: &str) -> Result<bool, RuntimeError>;
+    fn delete_permission(&mut self, permission: Vec<&str>) -> Result<bool, RuntimeError>;
+    fn delete_permission_for_user(
+        &mut self,
+        user: &str,
+        permission: Vec<&str>,
+    ) -> Result<bool, RuntimeError>;
+    fn delete_permissions_for_user(&mut self, user: &str) -> Result<bool, RuntimeError>;
     fn get_permissions_for_user(&self, user: &str) -> Vec<Vec<String>>;
     fn has_permission_for_user(&self, user: &str, permission: Vec<&str>) -> bool;
     fn get_implicit_roles_for_user(&mut self, name: &str, domain: Option<&str>) -> Vec<String>;
@@ -30,21 +38,25 @@ pub trait RbacApi {
 }
 
 impl<A: Adapter> RbacApi for Enforcer<A> {
-    fn add_permission_for_user(&mut self, user: &str, permission: Vec<&str>) -> Result<bool> {
+    fn add_permission_for_user(
+        &mut self,
+        user: &str,
+        permission: Vec<&str>,
+    ) -> Result<bool, RuntimeError> {
         let mut perm = permission;
         perm.insert(0, user);
         self.add_policy(perm)
     }
 
-    fn add_role_for_user(&mut self, user: &str, role: &str) -> Result<bool> {
+    fn add_role_for_user(&mut self, user: &str, role: &str) -> Result<bool, RuntimeError> {
         self.add_grouping_policy(vec![user, role])
     }
 
-    fn delete_role_for_user(&mut self, user: &str, role: &str) -> Result<bool> {
+    fn delete_role_for_user(&mut self, user: &str, role: &str) -> Result<bool, RuntimeError> {
         self.remove_grouping_policy(vec![user, role])
     }
 
-    fn delete_roles_for_user(&mut self, user: &str) -> Result<bool> {
+    fn delete_roles_for_user(&mut self, user: &str) -> Result<bool, RuntimeError> {
         self.remove_filtered_grouping_policy(0, vec![user])
     }
 
@@ -80,27 +92,31 @@ impl<A: Adapter> RbacApi for Enforcer<A> {
         has_role
     }
 
-    fn delete_user(&mut self, name: &str) -> Result<bool> {
+    fn delete_user(&mut self, name: &str) -> Result<bool, RuntimeError> {
         self.remove_filtered_grouping_policy(0, vec![name])
     }
 
-    fn delete_role(&mut self, name: &str) -> Result<bool> {
+    fn delete_role(&mut self, name: &str) -> Result<bool, RuntimeError> {
         let res1 = self.remove_filtered_grouping_policy(1, vec![name])?;
         let res2 = self.remove_filtered_policy(0, vec![name])?;
         Ok(res1 || res2)
     }
 
-    fn delete_permission(&mut self, permission: Vec<&str>) -> Result<bool> {
+    fn delete_permission(&mut self, permission: Vec<&str>) -> Result<bool, RuntimeError> {
         self.remove_filtered_policy(1, permission)
     }
 
-    fn delete_permission_for_user(&mut self, user: &str, permission: Vec<&str>) -> Result<bool> {
+    fn delete_permission_for_user(
+        &mut self,
+        user: &str,
+        permission: Vec<&str>,
+    ) -> Result<bool, RuntimeError> {
         let mut permission = permission;
         permission.insert(0, user);
         self.remove_policy(permission)
     }
 
-    fn delete_permissions_for_user(&mut self, user: &str) -> Result<bool> {
+    fn delete_permissions_for_user(&mut self, user: &str) -> Result<bool, RuntimeError> {
         self.remove_filtered_policy(0, vec![user])
     }
 


### PR DESCRIPTION
Currently, we treat all errors as `Box<dyn std::error::Error>`, this causes our errors lost type information, as a result, we got a string-based error type, which is not convenient for precise error match.

This pr added `ParseError` and `RuntimeError`, so people can know exactly which error occurs.

A simple example on how to do error matching:

```rust
match e.add_role_for_user("alice", "data1_admin") {
    Err(err) => {
        match err {
            RuntimeError::RoleNotExists => println!("handle role not exist error here {}", err),
            RuntimeError::IoError(s) => println!("handle io error here {}", s),
            RuntimeError::ParseError(pe) => println!("handle parse error here {}", pe),
            _ => println!("skip other errors {}", err),
        }
    },
    _ => {},
};
```

This should partly solve #24 , not sure if this is the ideal implementation.

@GopherJ @hsluoyz PTAL
@awakecoding can you help review this?