### PR TITLE
add in operator

### DIFF
--- a/src/adapter/file_adapter.rs
+++ b/src/adapter/file_adapter.rs
@@ -101,12 +101,13 @@ fn load_policy_line(line: String, m: &mut Model) {
     }
     let tokens: Vec<String> = line.split(',').map(|x| x.trim().to_string()).collect();
     let key = tokens[0].clone();
-    let sec = key.chars().nth(0).unwrap().to_string();
 
-    if let Some(t1) = m.model.get_mut(&sec) {
-        if let Some(t2) = t1.get_mut(&key) {
-            t2.policy.push(tokens[1..].to_vec());
-            t2.policy.dedup();
+    if let Some(sec) = key.chars().nth(0).map(|x| x.to_string()) {
+        if let Some(t1) = m.model.get_mut(&sec) {
+            if let Some(t2) = t1.get_mut(&key) {
+                t2.policy.push(tokens[1..].to_vec());
+                t2.policy.dedup();
+            }
         }
     }
 }

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -2,13 +2,11 @@ use crate::adapter::Adapter;
 use crate::effector::{DefaultEffector, EffectKind, Effector};
 use crate::error::{Error, ModelError};
 use crate::model::Model;
-use crate::model::{load_function_map, FunctionMap};
+use crate::model::{in_match, load_function_map, FunctionMap};
 use crate::rbac::{DefaultRoleManager, RoleManager};
 use crate::Result;
 
 use rhai::{Engine, RegisterFn, Scope};
-
-// use std::collections::HashMap;
 
 pub trait MatchFnClone2: Fn(String, String) -> bool {
     fn clone_box(&self) -> Box<dyn MatchFnClone2>;
@@ -181,6 +179,7 @@ impl<A: Adapter> Enforcer<A> {
         for (key, func) in self.fm.iter() {
             engine.register_fn(key.as_str(), func.clone());
         }
+        engine.register_fn("inMatch", in_match);
         if let Some(g_result) = self.model.model.get("g") {
             for (key, ast) in g_result.iter() {
                 if key == "g" {


### PR DESCRIPTION
Try to resolve #5 `Investigate how to parse in operator in config file @GopherJ`

This PR adds an `inMatch` function and a regex to handle `in` operator.

It will convert the following matcher:
```
g(r.sub, p.sub) && r.act in ["a","b","c"] && r.sub in ["alice","bob"] && r.obj in ["data1","data2"]
```
to
```
g(r.sub, p.sub) && inMatch(r.act, ["a","b","c"]) && inMatch(r.sub, ["alice","bob"]) && inMatch(r.obj, ["data1","data2"])
```

The supported `in` operations are:

```
r.sub in ["alice", "bob"]
```
OR
```
r.obj in ("a", "b")
```