### PR TITLE
using IndexSet to store policy in assertion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ description = "An authorization library that supports access control models like
 regex = "1.3.1"
 rhai = "0.9.1"
 ip_network = "0.3.4"
+indexmap = "1.3.1"

--- a/src/adapter/file_adapter.rs
+++ b/src/adapter/file_adapter.rs
@@ -110,8 +110,7 @@ fn load_policy_line(line: String, m: &mut Model) {
     if let Some(sec) = key.chars().next().map(|x| x.to_string()) {
         if let Some(t1) = m.model.get_mut(&sec) {
             if let Some(t2) = t1.get_mut(&key) {
-                t2.policy.push(tokens[1..].to_vec());
-                t2.policy.dedup();
+                t2.policy.insert(tokens[1..].to_vec());
             }
         }
     }

--- a/src/adapter/memory_adapter.rs
+++ b/src/adapter/memory_adapter.rs
@@ -17,8 +17,7 @@ impl Adapter for MemoryAdapter {
             let rule = line[1..].to_vec().clone();
             if let Some(t1) = m.model.get_mut(&sec) {
                 if let Some(t2) = t1.get_mut(&ptype) {
-                    t2.policy.push(rule);
-                    t2.policy.dedup();
+                    t2.policy.insert(rule);
                 }
             }
         }

--- a/src/management_api.rs
+++ b/src/management_api.rs
@@ -247,6 +247,11 @@ mod tests {
     use crate::model::Model;
     use crate::RbacApi;
 
+    fn sort_unstable<T: Ord>(mut v: Vec<T>) -> Vec<T> {
+        v.sort_unstable();
+        v
+    }
+
     #[test]
     fn test_modify_grouping_policy_api() {
         let m = Model::from_file("examples/rbac_model.conf").unwrap();
@@ -307,7 +312,7 @@ mod tests {
                 vec!["data2_admin", "data2", "read"],
                 vec!["data2_admin", "data2", "write"],
             ],
-            e.get_policy()
+            sort_unstable(e.get_policy())
         );
 
         e.remove_policy(vec!["alice", "data1", "read"]).unwrap();
@@ -326,7 +331,7 @@ mod tests {
                 vec!["data2_admin", "data2", "write"],
                 vec!["eve", "data3", "read"],
             ],
-            e.get_policy()
+            sort_unstable(e.get_policy())
         );
 
         e.remove_filtered_policy(1, vec!["data2"]).unwrap();
@@ -347,7 +352,7 @@ mod tests {
                 vec!["data2_admin", "data2", "read"],
                 vec!["data2_admin", "data2", "write"],
             ],
-            e.get_policy()
+            sort_unstable(e.get_policy())
         );
 
         assert_eq!(
@@ -363,7 +368,7 @@ mod tests {
                 vec!["data2_admin", "data2", "read"],
                 vec!["data2_admin", "data2", "write"],
             ],
-            e.get_filtered_policy(0, vec!["data2_admin"])
+            sort_unstable(e.get_filtered_policy(0, vec!["data2_admin"]))
         );
         assert_eq!(
             vec![vec!["alice", "data1", "read"],],
@@ -375,28 +380,28 @@ mod tests {
                 vec!["data2_admin", "data2", "read"],
                 vec!["data2_admin", "data2", "write"],
             ],
-            e.get_filtered_policy(1, vec!["data2"])
+            sort_unstable(e.get_filtered_policy(1, vec!["data2"]))
         );
         assert_eq!(
             vec![
                 vec!["alice", "data1", "read"],
                 vec!["data2_admin", "data2", "read"],
             ],
-            e.get_filtered_policy(2, vec!["read"])
+            sort_unstable(e.get_filtered_policy(2, vec!["read"]))
         );
         assert_eq!(
             vec![
                 vec!["bob", "data2", "write"],
                 vec!["data2_admin", "data2", "write"],
             ],
-            e.get_filtered_policy(2, vec!["write"])
+            sort_unstable(e.get_filtered_policy(2, vec!["write"]))
         );
         assert_eq!(
             vec![
                 vec!["data2_admin", "data2", "read"],
                 vec!["data2_admin", "data2", "write"],
             ],
-            e.get_filtered_policy(0, vec!["data2_admin", "data2"])
+            sort_unstable(e.get_filtered_policy(0, vec!["data2_admin", "data2"]))
         );
         // Note: "" (empty string) in fieldValues means matching all values.
         assert_eq!(
@@ -408,7 +413,7 @@ mod tests {
                 vec!["bob", "data2", "write"],
                 vec!["data2_admin", "data2", "write"],
             ],
-            e.get_filtered_policy(1, vec!["data2", "write"])
+            sort_unstable(e.get_filtered_policy(1, vec!["data2", "write"]))
         );
 
         assert_eq!(true, e.has_policy(vec!["alice", "data1", "read"]));
@@ -447,9 +452,12 @@ mod tests {
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
         let e = Enforcer::new(m, adapter);
 
-        assert_eq!(vec!["alice", "bob", "data2_admin"], e.get_all_subjects());
-        assert_eq!(vec!["data1", "data2"], e.get_all_objects());
-        assert_eq!(vec!["read", "write"], e.get_all_actions());
+        assert_eq!(
+            vec!["alice", "bob", "data2_admin"],
+            sort_unstable(e.get_all_subjects())
+        );
+        assert_eq!(vec!["data1", "data2"], sort_unstable(e.get_all_objects()));
+        assert_eq!(vec!["read", "write"], sort_unstable(e.get_all_actions()));
         assert_eq!(vec!["data2_admin"], e.get_all_roles());
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,11 +3,12 @@ use crate::error::{Error, ModelError, PolicyError};
 use crate::rbac::{DefaultRoleManager, RoleManager};
 use crate::Result;
 
+use indexmap::IndexSet;
 use ip_network::IpNetwork;
 use regex::Regex;
 use rhai::Any;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::convert::AsRef;
 use std::net::IpAddr;
 use std::path::Path;
@@ -37,7 +38,7 @@ pub struct Assertion {
     pub(crate) key: String,
     pub(crate) value: String,
     pub(crate) tokens: Vec<String>,
-    pub(crate) policy: HashSet<Vec<String>>,
+    pub(crate) policy: IndexSet<Vec<String>>,
     pub(crate) rm: Arc<RwLock<dyn RoleManager>>,
 }
 
@@ -47,18 +48,18 @@ impl Default for Assertion {
             key: String::new(),
             value: String::new(),
             tokens: vec![],
-            policy: HashSet::new(),
+            policy: IndexSet::new(),
             rm: Arc::new(RwLock::new(DefaultRoleManager::new(0))),
         }
     }
 }
 
 impl Assertion {
-    pub fn get_policy(&self) -> &HashSet<Vec<String>> {
+    pub fn get_policy(&self) -> &IndexSet<Vec<String>> {
         &self.policy
     }
 
-    pub fn get_mut_policy(&mut self) -> &mut HashSet<Vec<String>> {
+    pub fn get_mut_policy(&mut self) -> &mut IndexSet<Vec<String>> {
         &mut self.policy
     }
 
@@ -282,7 +283,7 @@ impl Model {
     ) -> Vec<String> {
         self.get_policy(sec, ptype)
             .into_iter()
-            .fold(HashSet::new(), |mut acc, x| {
+            .fold(IndexSet::new(), |mut acc, x| {
                 acc.insert(x[field_index].clone());
                 acc
             })
@@ -324,7 +325,7 @@ impl Model {
         let mut res = false;
         if let Some(t1) = self.model.get_mut(sec) {
             if let Some(t2) = t1.get_mut(ptype) {
-                let mut tmp: HashSet<Vec<String>> = HashSet::new();
+                let mut tmp: IndexSet<Vec<String>> = IndexSet::new();
                 for rule in t2.policy.iter() {
                     let mut matched = true;
                     for (i, field_value) in field_values.iter().enumerate() {

--- a/src/model.rs
+++ b/src/model.rs
@@ -7,7 +7,7 @@ use ip_network::IpNetwork;
 use regex::Regex;
 use rhai::Any;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::convert::AsRef;
 use std::net::IpAddr;
 use std::path::Path;
@@ -37,7 +37,7 @@ pub struct Assertion {
     pub(crate) key: String,
     pub(crate) value: String,
     pub(crate) tokens: Vec<String>,
-    pub(crate) policy: Vec<Vec<String>>,
+    pub(crate) policy: HashSet<Vec<String>>,
     pub(crate) rm: Arc<RwLock<dyn RoleManager>>,
 }
 
@@ -47,18 +47,18 @@ impl Default for Assertion {
             key: String::new(),
             value: String::new(),
             tokens: vec![],
-            policy: vec![],
+            policy: HashSet::new(),
             rm: Arc::new(RwLock::new(DefaultRoleManager::new(0))),
         }
     }
 }
 
 impl Assertion {
-    pub fn get_policy(&self) -> &Vec<Vec<String>> {
+    pub fn get_policy(&self) -> &HashSet<Vec<String>> {
         &self.policy
     }
 
-    pub fn get_mut_policy(&mut self) -> &mut Vec<Vec<String>> {
+    pub fn get_mut_policy(&mut self) -> &mut HashSet<Vec<String>> {
         &mut self.policy
     }
 
@@ -220,9 +220,9 @@ impl Model {
     pub fn add_policy(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> bool {
         if let Some(t1) = self.model.get_mut(sec) {
             if let Some(t2) = t1.get_mut(ptype) {
-                t2.policy.push(rule.into_iter().map(String::from).collect());
-                t2.policy.dedup(); // avoid re-add, policy rules should be unique
-                return true;
+                return t2
+                    .policy
+                    .insert(rule.into_iter().map(String::from).collect());
             }
         }
         false
@@ -231,7 +231,7 @@ impl Model {
     pub fn get_policy(&self, sec: &str, ptype: &str) -> Vec<Vec<String>> {
         if let Some(t1) = self.model.get(sec) {
             if let Some(t2) = t1.get(ptype) {
-                return t2.policy.clone();
+                return t2.policy.iter().map(|x| x.to_owned()).collect();
             }
         }
         vec![]
@@ -250,7 +250,7 @@ impl Model {
                 for rule in t2.policy.iter() {
                     let mut matched = true;
                     for (i, field_value) in field_values.iter().enumerate() {
-                        if field_value != &"" && &rule[field_index + i] != field_value {
+                        if !field_value.is_empty() && &rule[field_index + i] != field_value {
                             matched = false;
                             break;
                         }
@@ -280,25 +280,21 @@ impl Model {
         ptype: &str,
         field_index: usize,
     ) -> Vec<String> {
-        let mut values = vec![];
-        let policy = self.get_policy(sec, ptype);
-        for rule in policy {
-            values.push(rule[field_index].clone());
-        }
-        values.sort_unstable();
-        values.dedup(); // sort and then dedup will remove all duplicates
-        values
+        self.get_policy(sec, ptype)
+            .into_iter()
+            .fold(HashSet::new(), |mut acc, x| {
+                acc.insert(x[field_index].clone());
+                acc
+            })
+            .into_iter()
+            .collect()
     }
 
     pub fn remove_policy(&mut self, sec: &str, ptype: &str, rule: Vec<&str>) -> bool {
         if let Some(t1) = self.model.get_mut(sec) {
             if let Some(t2) = t1.get_mut(ptype) {
-                for (i, r) in t2.policy.iter().enumerate() {
-                    if r == &rule {
-                        t2.policy.remove(i);
-                        return true;
-                    }
-                }
+                let rule: Vec<String> = rule.iter().map(|&x| String::from(x)).collect();
+                return t2.policy.remove(&rule);
             }
         }
         false
@@ -306,13 +302,14 @@ impl Model {
 
     pub fn clear_policy(&mut self) {
         if let Some(model_p) = self.model.get_mut("p") {
-            for (_key, ast) in model_p.iter_mut() {
-                ast.policy = vec![];
+            for ast in model_p.values_mut() {
+                ast.policy.clear();
             }
         }
+
         if let Some(model_g) = self.model.get_mut("g") {
-            for (_key, ast) in model_g.iter_mut() {
-                ast.policy = vec![];
+            for ast in model_g.values_mut() {
+                ast.policy.clear();
             }
         }
     }
@@ -325,13 +322,13 @@ impl Model {
         field_values: Vec<&str>,
     ) -> bool {
         let mut res = false;
-        let mut tmp: Vec<Vec<String>> = vec![];
         if let Some(t1) = self.model.get_mut(sec) {
             if let Some(t2) = t1.get_mut(ptype) {
-                for (_, rule) in t2.policy.iter().enumerate() {
+                let mut tmp: HashSet<Vec<String>> = HashSet::new();
+                for rule in t2.policy.iter() {
                     let mut matched = true;
                     for (i, field_value) in field_values.iter().enumerate() {
-                        if !field_value.is_empty() && rule[field_index + i] != *field_value {
+                        if !field_value.is_empty() && &rule[field_index + i] != field_value {
                             matched = false;
                             break;
                         }
@@ -339,15 +336,9 @@ impl Model {
                     if matched {
                         res = true;
                     } else {
-                        tmp.push(rule.clone());
+                        tmp.insert(rule.clone());
                     }
                 }
-            }
-        }
-
-        // update new policy
-        if let Some(t1) = self.model.get_mut(sec) {
-            if let Some(t2) = t1.get_mut(ptype) {
                 t2.policy = tmp;
             }
         }

--- a/src/rbac_api.rs
+++ b/src/rbac_api.rs
@@ -194,6 +194,11 @@ mod tests {
     use crate::enforcer::Enforcer;
     use crate::model::Model;
 
+    fn sort_unstable<T: Ord>(mut v: Vec<T>) -> Vec<T> {
+        v.sort_unstable();
+        v
+    }
+
     #[test]
     fn test_role_api() {
         let m = Model::from_file("examples/rbac_model.conf").unwrap();
@@ -211,8 +216,8 @@ mod tests {
 
         e.add_role_for_user("alice", "data1_admin").unwrap();
         assert_eq!(
-            vec!["data2_admin", "data1_admin"],
-            e.get_roles_for_user("alice")
+            vec!["data1_admin", "data2_admin"],
+            sort_unstable(e.get_roles_for_user("alice"))
         );
         assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob"));
         assert_eq!(vec![String::new(); 0], e.get_roles_for_user("data2_admin"));
@@ -297,8 +302,8 @@ mod tests {
                 .add_role_for_user("alice", "data1_admin")
                 .unwrap();
             assert_eq!(
-                vec!["data2_admin", "data1_admin"],
-                ee.write().unwrap().get_roles_for_user("alice")
+                vec!["data1_admin", "data2_admin"],
+                sort_unstable(ee.write().unwrap().get_roles_for_user("alice"))
             );
             assert_eq!(
                 vec![String::new(); 0],
@@ -554,7 +559,7 @@ mod tests {
 
         assert_eq!(
             vec!["admin", "data1_admin", "data2_admin"],
-            e.get_implicit_roles_for_user("alice", None)
+            sort_unstable(e.get_implicit_roles_for_user("alice", None))
         );
         assert_eq!(
             vec![String::new(); 0],
@@ -586,7 +591,7 @@ mod tests {
                 vec!["data2_admin", "data2", "read"],
                 vec!["data2_admin", "data2", "write"],
             ],
-            e.get_implicit_permissions_for_user("alice", None)
+            sort_unstable(e.get_implicit_permissions_for_user("alice", None))
         );
         assert_eq!(
             vec![vec!["bob", "data2", "write"]],
@@ -615,7 +620,7 @@ mod tests {
         );
         assert_eq!(
             vec!["alice", "bob"],
-            e.get_implicit_users_for_permission(vec!["data2", "write"])
+            sort_unstable(e.get_implicit_users_for_permission(vec!["data2", "write"]))
         );
     }
 
@@ -632,7 +637,7 @@ mod tests {
                 vec!["role:reader", "domain1", "data1", "read"],
                 vec!["role:writer", "domain1", "data1", "write"],
             ],
-            e.get_implicit_permissions_for_user("alice", Some("domain1"))
+            sort_unstable(e.get_implicit_permissions_for_user("alice", Some("domain1")))
         );
     }
 }


### PR DESCRIPTION
Previously we are using `sort_unstable` + `dedup` to avoid adding a policy the second time, but the sort operation is expensive, so I made this PR which stores policies in `HashSet`, in rust there is no problem to compare two arrays.

That'll probably make it more efficient.