### PR TITLE
fix DefaultRoleManager::get_users && add domain paramter to get_roles…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casbin"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Joey <joey.xf@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this package to `Cargo.toml` of your project. (Check https://crates.io/crate
 
 ```toml
 [dependencies]
-casbin = "0.1.2"
+casbin = "0.1.4"
 ```
 
 ## Get started
@@ -33,7 +33,7 @@ casbin = "0.1.2"
 ```rust
 use casbin::{Enforcer, Model, FileAdapter};
 
-let model = Model::from_file("path/to/model.conf");
+let model = Model::from_file("path/to/model.conf")?;
 let adapter = FileAdapter::new("path/to/policy.csv");
 
 let e = Enforcer::new(model, adapter);

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -454,7 +454,7 @@ mod tests {
             .unwrap();
         e.add_permission_for_user("data2_admin", vec!["data2", "write"])
             .unwrap();
-        e.add_role_for_user("alice", "data2_admin").unwrap();
+        e.add_role_for_user("alice", "data2_admin", None).unwrap();
 
         assert_eq!(true, e.enforce(vec!["alice", "data1", "read"]).unwrap());
         assert_eq!(false, e.enforce(vec!["alice", "data1", "write"]).unwrap());

--- a/src/internal_api.rs
+++ b/src/internal_api.rs
@@ -21,7 +21,7 @@ impl<A: Adapter> InternalApi for Enforcer<A> {
             return Ok(false);
         }
         if self.auto_save {
-            return self.adapter.add_policy(sec, ptype, rule.clone());
+            return self.adapter.add_policy(sec, ptype, rule);
         }
         Ok(rule_added)
     }
@@ -32,7 +32,7 @@ impl<A: Adapter> InternalApi for Enforcer<A> {
             return Ok(false);
         }
         if self.auto_save {
-            return self.adapter.remove_policy(sec, ptype, rule.clone());
+            return self.adapter.remove_policy(sec, ptype, rule);
         }
         Ok(rule_removed)
     }
@@ -51,12 +51,9 @@ impl<A: Adapter> InternalApi for Enforcer<A> {
             return Ok(false);
         }
         if self.auto_save {
-            return self.adapter.remove_filtered_policy(
-                sec,
-                ptype,
-                field_index,
-                field_values.clone(),
-            );
+            return self
+                .adapter
+                .remove_filtered_policy(sec, ptype, field_index, field_values);
         }
         Ok(rule_removed)
     }


### PR DESCRIPTION
While reviewing RBAC apis, I found some small problems. Like `add_role_for_user` doesn't accept **domain** parameter but it should.

Also it's not necessary to have:

```rust
 fn get_permissions_for_user(&self, user: &str) -> Vec<Vec<String>>;
 fn get_permissions_for_user_in_domain(&self, user: &str, domain: Option<&str>) -> Vec<Vec<String>>;
```

because we can merge them into:

```rust
fn get_permissions_for_user(&self, user: &str, domain: Option<&str>) -> Vec<Vec<String>>;
```

Another problem is about `DefaultRoleManager`, the previous `get_users` function is incorrect and we don't have unit tests for it so we didn't find this problem.