### PR TITLE
fix more rbac apis (add missing domain parameter) & add prelude module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casbin"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Joey <joey.xf@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this package to `Cargo.toml` of your project. (Check https://crates.io/crate
 
 ```toml
 [dependencies]
-casbin = "0.1.4"
+casbin = "0.1.5"
 ```
 
 ## Get started
@@ -31,7 +31,7 @@ casbin = "0.1.4"
 1. New a Casbin enforcer with a model file and a policy file:
 
 ```rust
-use casbin::{Enforcer, Model, FileAdapter};
+use casbin::prelude::*;
 
 let model = Model::from_file("path/to/model.conf")?;
 let adapter = FileAdapter::new("path/to/policy.csv");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ mod rbac;
 mod rbac_api;
 
 pub mod error;
+pub mod prelude;
+
 pub use adapter::{Adapter, FileAdapter};
 pub use enforcer::Enforcer;
 pub use internal_api::InternalApi;

--- a/src/management_api.rs
+++ b/src/management_api.rs
@@ -254,10 +254,13 @@ mod tests {
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
         let mut e = Enforcer::new(m, adapter);
 
-        assert_eq!(vec!["data2_admin"], e.get_roles_for_user("alice"));
-        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob"));
-        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("eve"));
-        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("non_exist"));
+        assert_eq!(vec!["data2_admin"], e.get_roles_for_user("alice", None));
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob", None));
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("eve", None));
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_roles_for_user("non_exist", None)
+        );
 
         e.remove_grouping_policy(vec!["alice", "data2_admin"])
             .unwrap();
@@ -265,10 +268,10 @@ mod tests {
         e.add_grouping_policy(vec!["eve", "data3_admin"]).unwrap();
 
         let named_grouping_policy = vec!["alice", "data2_admin"];
-        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice"));
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice", None));
         e.add_named_grouping_policy("g", named_grouping_policy.clone())
             .unwrap();
-        assert_eq!(vec!["data2_admin"], e.get_roles_for_user("alice"));
+        assert_eq!(vec!["data2_admin"], e.get_roles_for_user("alice", None));
         e.remove_named_grouping_policy("g", named_grouping_policy.clone())
             .unwrap();
 
@@ -277,20 +280,32 @@ mod tests {
         e.add_grouping_policy(vec!["bob", "data1_admin"]).unwrap();
         e.add_grouping_policy(vec!["eve", "data3_admin"]).unwrap();
 
-        assert_eq!(vec!["bob"], e.get_users_for_role("data1_admin"));
-        assert_eq!(vec![String::new(); 0], e.get_users_for_role("data2_admin"));
-        assert_eq!(vec!["eve"], e.get_users_for_role("data3_admin"));
+        assert_eq!(vec!["bob"], e.get_users_for_role("data1_admin", None));
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_users_for_role("data2_admin", None)
+        );
+        assert_eq!(vec!["eve"], e.get_users_for_role("data3_admin", None));
 
         e.remove_filtered_grouping_policy(0, vec!["bob"]).unwrap();
 
-        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice"));
-        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob"));
-        assert_eq!(vec!["data3_admin"], e.get_roles_for_user("eve"));
-        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("non_exist"));
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice", None));
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob", None));
+        assert_eq!(vec!["data3_admin"], e.get_roles_for_user("eve", None));
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_roles_for_user("non_exist", None)
+        );
 
-        assert_eq!(vec![String::new(); 0], e.get_users_for_role("data1_admin"));
-        assert_eq!(vec![String::new(); 0], e.get_users_for_role("data2_admin"));
-        assert_eq!(vec!["eve"], e.get_users_for_role("data3_admin"));
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_users_for_role("data1_admin", None)
+        );
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_users_for_role("data2_admin", None)
+        );
+        assert_eq!(vec!["eve"], e.get_users_for_role("data3_admin", None));
     }
 
     #[test]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,1 @@
+pub use crate::{Enforcer, FileAdapter, InternalApi, MgmtApi, Model, RbacApi};


### PR DESCRIPTION
This PR fix more rbac apis which don't have domain parameter.

It adds also the prelude module which implements `management api`, `internal api`, `rbac api` etc.

Instead of doing:

```rust
use casbin::{Model, Enforcer, FileAdapter};
use casbin::{RbacApi, MgmtApi, InternalApi};
```

we can now do:
```rust
use casbin::prelude::*;
```