### PR TITLE
Added Unit Tests for `addPolicies` and `removePolicies`

### DIFF
--- a/src/management_api.rs
+++ b/src/management_api.rs
@@ -818,13 +818,13 @@ mod tests {
         assert_eq!(vec!["read", "write"], sort_unstable(e.get_all_actions()));
         assert_eq!(vec!["data2_admin"], e.get_all_roles());
     }
-    
+
     #[cfg_attr(feature = "runtime-async-std", async_std::test)]
     #[cfg_attr(feature = "runtime-tokio", tokio::test)]
     async fn test_modify_policies_api() {
         let m = DefaultModel::from_file("examples/rbac_model.conf")
-        .await
-        .unwrap();
+            .await
+            .unwrap();
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
         let mut e = Enforcer::new(Box::new(m), Box::new(adapter)).await.unwrap();
@@ -839,20 +839,32 @@ mod tests {
             sort_unstable(e.get_policy())
         );
 
-        e.remove_policies(vec![vec!["alice", "data1", "read"], vec!["bob", "data2", "write"]])
-            .await
-            .unwrap();
+        e.remove_policies(vec![
+            vec!["alice", "data1", "read"],
+            vec!["bob", "data2", "write"],
+        ])
+        .await
+        .unwrap();
         e.remove_policies(vec![vec!["alice", "data1", "read"]])
             .await
             .unwrap();
-        e.add_policies(vec![vec!["eve", "data3", "read"]]).await.unwrap();
-        e.add_policies(vec![vec!["eve", "data3", "read"], vec!["eve", "data3", "read"]]).await.unwrap();
+        e.add_policies(vec![vec!["eve", "data3", "read"]])
+            .await
+            .unwrap();
+        e.add_policies(vec![
+            vec!["eve", "data3", "read"],
+            vec!["eve", "data3", "read"],
+        ])
+        .await
+        .unwrap();
 
         let named_policy = vec!["eve", "data3", "read"];
         e.remove_named_policies("p", vec![named_policy.clone()])
             .await
             .unwrap();
-        e.add_named_policies("p", vec![named_policy.clone()]).await.unwrap();
+        e.add_named_policies("p", vec![named_policy.clone()])
+            .await
+            .unwrap();
 
         assert_eq!(
             vec![
@@ -905,10 +917,10 @@ mod tests {
         e.remove_grouping_policies(vec![vec!["alice", "data2_admin"]])
             .await
             .unwrap();
-        e.add_grouping_policies(vec![vec!["bob", "data1_admin"],vec!["eve", "data3_admin"]])
+
+        e.add_grouping_policies(vec![vec!["bob", "data1_admin"], vec!["eve", "data3_admin"]])
             .await
             .unwrap();
-
 
         assert_eq!(vec!["bob"], e.get_users_for_role("data1_admin", None));
         assert_eq!(

--- a/src/management_api.rs
+++ b/src/management_api.rs
@@ -848,6 +848,10 @@ mod tests {
         e.remove_policies(vec![vec!["alice", "data1", "read"]])
             .await
             .unwrap();
+        assert_eq!(false, e.has_policy(vec!["alice", "data1", "read"]));
+        assert_eq!(false, e.has_policy(vec!["bob", "data2", "write"]));
+        assert_eq!(true, e.has_policy(vec!["data2_admin", "data2", "read"]));
+        assert_eq!(true, e.has_policy(vec!["data2_admin", "data2", "write"]));
         e.add_policies(vec![vec!["eve", "data3", "read"]])
             .await
             .unwrap();
@@ -857,6 +861,11 @@ mod tests {
         ])
         .await
         .unwrap();
+        assert_eq!(false, e.has_policy(vec!["alice", "data1", "read"]));
+        assert_eq!(false, e.has_policy(vec!["bob", "data2", "write"]));
+        assert_eq!(true, e.has_policy(vec!["eve", "data3", "read"]));
+        assert_eq!(true, e.has_policy(vec!["data2_admin", "data2", "read"]));
+        assert_eq!(true, e.has_policy(vec!["data2_admin", "data2", "write"]));
 
         let named_policy = vec!["eve", "data3", "read"];
         e.remove_named_policies("p", vec![named_policy.clone()])
@@ -903,6 +912,9 @@ mod tests {
         e.add_grouping_policies(vec![vec!["bob", "data1_admin"], vec!["eve", "data3_admin"]])
             .await
             .unwrap();
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice", None));
+        assert_eq!(vec!["data1_admin"], e.get_roles_for_user("bob", None));
+        assert_eq!(vec!["data3_admin"], e.get_roles_for_user("eve", None));
 
         let named_grouping_policy = vec!["alice", "data2_admin"];
         assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice", None));

--- a/src/management_api.rs
+++ b/src/management_api.rs
@@ -818,4 +818,125 @@ mod tests {
         assert_eq!(vec!["read", "write"], sort_unstable(e.get_all_actions()));
         assert_eq!(vec!["data2_admin"], e.get_all_roles());
     }
+    
+    #[cfg_attr(feature = "runtime-async-std", async_std::test)]
+    #[cfg_attr(feature = "runtime-tokio", tokio::test)]
+    async fn test_modify_policies_api() {
+        let m = DefaultModel::from_file("examples/rbac_model.conf")
+        .await
+        .unwrap();
+
+        let adapter = FileAdapter::new("examples/rbac_policy.csv");
+        let mut e = Enforcer::new(Box::new(m), Box::new(adapter)).await.unwrap();
+
+        assert_eq!(
+            vec![
+                vec!["alice", "data1", "read"],
+                vec!["bob", "data2", "write"],
+                vec!["data2_admin", "data2", "read"],
+                vec!["data2_admin", "data2", "write"],
+            ],
+            sort_unstable(e.get_policy())
+        );
+
+        e.remove_policies(vec![vec!["alice", "data1", "read"], vec!["bob", "data2", "write"]])
+            .await
+            .unwrap();
+        e.remove_policies(vec![vec!["alice", "data1", "read"]])
+            .await
+            .unwrap();
+        e.add_policies(vec![vec!["eve", "data3", "read"]]).await.unwrap();
+        e.add_policies(vec![vec!["eve", "data3", "read"], vec!["eve", "data3", "read"]]).await.unwrap();
+
+        let named_policy = vec!["eve", "data3", "read"];
+        e.remove_named_policies("p", vec![named_policy.clone()])
+            .await
+            .unwrap();
+        e.add_named_policies("p", vec![named_policy.clone()]).await.unwrap();
+
+        assert_eq!(
+            vec![
+                vec!["data2_admin", "data2", "read"],
+                vec!["data2_admin", "data2", "write"],
+                vec!["eve", "data3", "read"],
+            ],
+            sort_unstable(e.get_policy())
+        );
+
+        e.remove_filtered_policy(1, vec!["data2"]).await.unwrap();
+        assert_eq!(vec![vec!["eve", "data3", "read"],], e.get_policy());
+    }
+
+    #[cfg_attr(feature = "runtime-async-std", async_std::test)]
+    #[cfg_attr(feature = "runtime-tokio", tokio::test)]
+    async fn test_modify_grouping_policies_api() {
+        let m = DefaultModel::from_file("examples/rbac_model.conf")
+            .await
+            .unwrap();
+
+        let adapter = FileAdapter::new("examples/rbac_policy.csv");
+        let mut e = Enforcer::new(Box::new(m), Box::new(adapter)).await.unwrap();
+
+        assert_eq!(vec!["data2_admin"], e.get_roles_for_user("alice", None));
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob", None));
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("eve", None));
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_roles_for_user("non_exist", None)
+        );
+
+        e.remove_grouping_policies(vec![vec!["alice", "data2_admin"]])
+            .await
+            .unwrap();
+        e.add_grouping_policies(vec![vec!["bob", "data1_admin"], vec!["eve", "data3_admin"]])
+            .await
+            .unwrap();
+
+        let named_grouping_policy = vec!["alice", "data2_admin"];
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice", None));
+        e.add_named_grouping_policies("g", vec![named_grouping_policy.clone()])
+            .await
+            .unwrap();
+        assert_eq!(vec!["data2_admin"], e.get_roles_for_user("alice", None));
+        e.remove_named_grouping_policies("g", vec![named_grouping_policy.clone()])
+            .await
+            .unwrap();
+
+        e.remove_grouping_policies(vec![vec!["alice", "data2_admin"]])
+            .await
+            .unwrap();
+        e.add_grouping_policies(vec![vec!["bob", "data1_admin"],vec!["eve", "data3_admin"]])
+            .await
+            .unwrap();
+
+
+        assert_eq!(vec!["bob"], e.get_users_for_role("data1_admin", None));
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_users_for_role("data2_admin", None)
+        );
+        assert_eq!(vec!["eve"], e.get_users_for_role("data3_admin", None));
+
+        e.remove_filtered_grouping_policy(0, vec!["bob"])
+            .await
+            .unwrap();
+
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice", None));
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob", None));
+        assert_eq!(vec!["data3_admin"], e.get_roles_for_user("eve", None));
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_roles_for_user("non_exist", None)
+        );
+
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_users_for_role("data1_admin", None)
+        );
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_users_for_role("data2_admin", None)
+        );
+        assert_eq!(vec!["eve"], e.get_users_for_role("data3_admin", None));
+    }
 }

--- a/src/rbac_api.rs
+++ b/src/rbac_api.rs
@@ -459,7 +459,7 @@ mod tests {
             vec!["data1_admin", "data2_admin"],
             e.get_roles_for_user("bob", None)
         );
-        
+
         e.delete_roles_for_user("bob", None).await.unwrap();
         assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice", None));
         assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob", None));
@@ -569,7 +569,7 @@ mod tests {
                             vec![String::new(); 0],
                             ee.write().unwrap().get_roles_for_user("data2_admin", None)
                         );
-                        
+
                         ee.write()
                         .unwrap()
                         .add_roles_for_user("bob",vec!["data2_admin"], None)
@@ -615,13 +615,13 @@ mod tests {
                                 vec![String::new(); 0],
                                 ee.write().unwrap().get_roles_for_user("data2_admin", None)
                             );
-                        
+
                             ee.write()
                             .unwrap()
                             .add_roles_for_user("bob",vec!["data2_admin"], None)
                             .await
                             .unwrap();
-    
+
                             assert_eq!(
                                 vec!["data2_admin", "data1_admin"],
                                 ee.write().unwrap().get_roles_for_user("alice", None)
@@ -633,7 +633,7 @@ mod tests {
                             assert_eq!(
                                 vec![String::new(); 0],
                                 ee.write().unwrap().get_roles_for_user("data2_admin", None)
-                            );    
+                            );
                         });
                 }
             }

--- a/src/rbac_api.rs
+++ b/src/rbac_api.rs
@@ -451,6 +451,19 @@ mod tests {
             e.get_roles_for_user("data2_admin", None)
         );
 
+        e.add_roles_for_user("bob", vec!["data1_admin", "data2_admin"], None)
+            .await
+            .unwrap();
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice", None));
+        assert_eq!(
+            vec!["data1_admin", "data2_admin"],
+            e.get_roles_for_user("bob", None)
+        );
+        
+        e.delete_roles_for_user("bob", None).await.unwrap();
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("alice", None));
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob", None));
+
         e.add_role_for_user("alice", "data1_admin", None)
             .await
             .unwrap();
@@ -556,6 +569,25 @@ mod tests {
                             vec![String::new(); 0],
                             ee.write().unwrap().get_roles_for_user("data2_admin", None)
                         );
+                        
+                        ee.write()
+                        .unwrap()
+                        .add_roles_for_user("bob",vec!["data2_admin"], None)
+                        .await
+                        .unwrap();
+
+                        assert_eq!(
+                            vec!["data2_admin", "data1_admin"],
+                            ee.write().unwrap().get_roles_for_user("alice", None)
+                        );
+                        assert_eq!(
+                            vec!["data2_admin"],
+                            ee.write().unwrap().get_roles_for_user("bob", None)
+                        );
+                        assert_eq!(
+                            vec![String::new(); 0],
+                            ee.write().unwrap().get_roles_for_user("data2_admin", None)
+                        );
                     });
                 } else if #[cfg(feature = "runtime-tokio")] {
                     tokio::runtime::Builder::new()
@@ -583,6 +615,25 @@ mod tests {
                                 vec![String::new(); 0],
                                 ee.write().unwrap().get_roles_for_user("data2_admin", None)
                             );
+                        
+                            ee.write()
+                            .unwrap()
+                            .add_roles_for_user("bob",vec!["data2_admin"], None)
+                            .await
+                            .unwrap();
+    
+                            assert_eq!(
+                                vec!["data2_admin", "data1_admin"],
+                                ee.write().unwrap().get_roles_for_user("alice", None)
+                            );
+                            assert_eq!(
+                                vec!["data2_admin"],
+                                ee.write().unwrap().get_roles_for_user("bob", None)
+                            );
+                            assert_eq!(
+                                vec![String::new(); 0],
+                                ee.write().unwrap().get_roles_for_user("data2_admin", None)
+                            );    
                         });
                 }
             }
@@ -593,6 +644,11 @@ mod tests {
         e.write()
             .unwrap()
             .delete_role_for_user("alice", "data1_admin", None)
+            .await
+            .unwrap();
+        e.write()
+            .unwrap()
+            .delete_roles_for_user("bob", None)
             .await
             .unwrap();
         assert_eq!(
@@ -805,11 +861,16 @@ mod tests {
         e.add_permission_for_user("bob", vec!["read"])
             .await
             .unwrap();
+        e.add_permissions_for_user("eve", vec![vec!["read"], vec!["write"]])
+            .await
+            .unwrap();
 
         assert_eq!(false, e.enforce(vec!["alice", "read"]).unwrap());
         assert_eq!(false, e.enforce(vec!["alice", "write"]).unwrap());
         assert_eq!(true, e.enforce(vec!["bob", "read"]).unwrap());
         assert_eq!(true, e.enforce(vec!["bob", "write"]).unwrap());
+        assert_eq!(true, e.enforce(vec!["eve", "read"]).unwrap());
+        assert_eq!(true, e.enforce(vec!["eve", "write"]).unwrap());
 
         e.delete_permission_for_user("bob", vec!["read"])
             .await
@@ -819,13 +880,18 @@ mod tests {
         assert_eq!(false, e.enforce(vec!["alice", "write"]).unwrap());
         assert_eq!(false, e.enforce(vec!["bob", "read"]).unwrap());
         assert_eq!(true, e.enforce(vec!["bob", "write"]).unwrap());
+        assert_eq!(true, e.enforce(vec!["eve", "read"]).unwrap());
+        assert_eq!(true, e.enforce(vec!["eve", "write"]).unwrap());
 
         e.delete_permissions_for_user("bob").await.unwrap();
+        e.delete_permissions_for_user("eve").await.unwrap();
 
         assert_eq!(false, e.enforce(vec!["alice", "read"]).unwrap());
         assert_eq!(false, e.enforce(vec!["alice", "write"]).unwrap());
         assert_eq!(false, e.enforce(vec!["bob", "read"]).unwrap());
         assert_eq!(false, e.enforce(vec!["bob", "write"]).unwrap());
+        assert_eq!(false, e.enforce(vec!["eve", "read"]).unwrap());
+        assert_eq!(false, e.enforce(vec!["eve", "write"]).unwrap());
     }
 
     #[cfg_attr(feature = "runtime-async-std", async_std::test)]


### PR DESCRIPTION
Fixes #65.
Added the following tests in `management_api.rs`:
- `test_modify_policies_api`
- `test_modify_grouping_policies_api`

For:
```rust
async fn add_policies(&mut self, paramss: Vec<Vec<&str>>) -> Result<bool>;
async fn remove_policies(&mut self, paramss: Vec<Vec<&str>>) -> Result<bool>;
async fn add_named_policies(&mut self, ptype: &str, paramss: Vec<Vec<&str>>) -> Result<bool>;
async fn remove_named_policies(&mut self, ptype: &str, paramss: Vec<Vec<&str>>)
        -> Result<bool>;
async fn add_grouping_policies(&mut self, paramss: Vec<Vec<&str>>) -> Result<bool>;
async fn remove_grouping_policies(&mut self, paramss: Vec<Vec<&str>>) -> Result<bool>;
async fn add_named_grouping_policies(
        &mut self,
        ptype: &str,
        paramss: Vec<Vec<&str>>,
    ) -> Result<bool>;
async fn remove_named_grouping_policies(
        &mut self,
        ptype: &str,
        paramss: Vec<Vec<&str>>,
    ) -> Result<bool>;
```

Modified the following tests in `rbac_api.rs`:
- `test_role_api`
- `test_permission_api`
- `test_role_api_threads`

For:
```rust
async fn add_permissions_for_user(
        &mut self,
        user: &str,
        permissions: Vec<Vec<&str>>,
    ) -> Result<bool>;
async fn add_roles_for_user(
        &mut self,
        user: &str,
        roles: Vec<&str>,
        domain: Option<&str>,
    ) -> Result<bool>;
```