### PR TITLE
add c ffi so people can call casbin-rs from c code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ async-std = { version = "1.5.0", optional = true }
 async-trait = "0.1.24"
 log = "0.4.8"
 tokio = { version = "0.2.11", optional = true, default-features = false }
+futures = "0.3"
 
 [features]
 default = ["runtime-async-std"]
@@ -42,6 +43,7 @@ criterion = "0.3"
 
 [lib]
 bench = false
+crate-type =["cdylib"]
 
 [[bench]]
 name = "casbin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ async-std = { version = "1.5.0", optional = true }
 async-trait = "0.1.24"
 log = "0.4.8"
 tokio = { version = "0.2.11", optional = true, default-features = false }
-futures = "0.3"
 
 [features]
 default = ["runtime-async-std"]

--- a/src/ffi/c.h
+++ b/src/ffi/c.h
@@ -1,0 +1,22 @@
+// casbin c ffi header
+
+struct Enforcer;
+extern struct Enforcer* new_enforcer(char* conf_file, char* policy_file);
+extern int enforce(struct Enforcer* enforcer, char *sub, char *obj, char *act);
+
+// how to use this header, a demo ffi.c file
+
+// #include <stdio.h>
+// #include "c.h"
+
+// int main() {
+//     struct Enforcer* e = new_enforcer("examples/basic_model.conf", "examples/basic_policy.csv");
+
+//     int res1 = enforce(e, "alice", "data1", "read");
+//     int res2 = enforce(e, "alice", "data1", "write");
+
+//     printf("res1=%d\n", res1);
+//     printf("res2=%d\n", res2);
+
+//     return 0;
+// }

--- a/src/ffi/c.h
+++ b/src/ffi/c.h
@@ -1,8 +1,18 @@
 // casbin c ffi header
 
 struct Enforcer;
-extern struct Enforcer* new_enforcer(char* conf_file, char* policy_file);
-extern int enforce(struct Enforcer* enforcer, char *sub, char *obj, char *act);
+struct Adapter;
+
+extern struct Adapter *new_adapter(char *dsn);
+
+// TODO: If we have a new adapter we must add a new declaration here, any better method?
+extern struct Adapter *new_diesel_adapter(char *dsn);
+
+extern struct Enforcer *new_enforcer(char *conf_file, struct Adapter *adapter_ptr);
+extern int enforce(struct Enforcer *enforcer, char *sub, char *obj, char *act);
+
+// RBAC APIs
+extern char **get_roles_for_user(struct Enforcer *enforcer, char *name);
 
 // how to use this header, a demo ffi.c file
 
@@ -10,13 +20,19 @@ extern int enforce(struct Enforcer* enforcer, char *sub, char *obj, char *act);
 // #include "c.h"
 
 // int main() {
-//     struct Enforcer* e = new_enforcer("examples/basic_model.conf", "examples/basic_policy.csv");
-
+//     // struct Adapter *adapter = new_diesel_adapter("postgres://username:passwd@127.0.0.1/database");
+//     struct Adapter *adapter = new_adapter("examples/basic_policy.csv");
+//     struct Enforcer *e = new_enforcer("examples/basic_model.conf", adapter);
 //     int res1 = enforce(e, "alice", "data1", "read");
 //     int res2 = enforce(e, "alice", "data1", "write");
-
 //     printf("res1=%d\n", res1);
 //     printf("res2=%d\n", res2);
+
+//     // test rbac api
+//     struct Adapter *adapter2 = new_adapter("examples/rbac_policy.csv");
+//     struct Enforcer *e2 = new_enforcer("examples/rbac_model.conf", adapter2);
+//     char **roles = get_roles_for_user(e2, "alice");
+//     printf("%s\n", roles[0]);
 
 //     return 0;
 // }

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -1,19 +1,27 @@
-use crate::{DefaultModel, Enforcer, FileAdapter};
+use crate::{Adapter, DefaultModel, Enforcer, FileAdapter, RbacApi};
 use async_std::task::block_on;
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+
+#[no_mangle]
+pub extern "C" fn new_adapter(dsn: *const c_char) -> Box<dyn Adapter> {
+    let dsn = unsafe { CStr::from_ptr(dsn) };
+    let adapter = FileAdapter::new(dsn.to_str().unwrap());
+
+    Box::new(adapter)
+}
 
 #[no_mangle]
 pub extern "C" fn new_enforcer(
     conf_file: *const c_char,
-    policy_file: *const c_char,
+    adapter_ptr: *mut dyn Adapter,
 ) -> Box<Enforcer> {
     let conf_file = unsafe { CStr::from_ptr(conf_file) };
     let m = block_on(DefaultModel::from_file(conf_file.to_str().unwrap())).unwrap();
 
-    let policy_file = unsafe { CStr::from_ptr(policy_file) };
-    let adapter = FileAdapter::new(policy_file.to_str().unwrap());
-    let e = block_on(Enforcer::new(Box::new(m), Box::new(adapter))).unwrap();
+    // let adapter = new_adapter(dsn);
+    let adapter = unsafe { Box::from_raw(adapter_ptr) };
+    let e = block_on(Enforcer::new(Box::new(m), adapter)).unwrap();
 
     Box::new(e)
 }
@@ -35,4 +43,20 @@ pub extern "C" fn enforce(
             act.to_str().unwrap(),
         ])
         .unwrap()
+}
+
+#[no_mangle]
+pub extern "C" fn get_roles_for_user(
+    enforcer: &mut Enforcer,
+    name: *const c_char,
+) -> *const *const c_char {
+    let name = unsafe { CStr::from_ptr(name) };
+    let rs_name = name.to_str().unwrap();
+    let roles = enforcer.get_roles_for_user(rs_name, None);
+
+    let v: Vec<*const c_char> = roles
+        .iter()
+        .map(|role| CString::new(role.as_str()).unwrap().as_ptr())
+        .collect();
+    v.as_ptr()
 }

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -1,0 +1,38 @@
+use crate::{DefaultModel, Enforcer, FileAdapter};
+use futures::executor::block_on;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+#[no_mangle]
+pub extern "C" fn new_enforcer(
+    conf_file: *const c_char,
+    policy_file: *const c_char,
+) -> Box<Enforcer> {
+    let conf_file = unsafe { CStr::from_ptr(conf_file) };
+    let m = block_on(DefaultModel::from_file(conf_file.to_str().unwrap())).unwrap();
+
+    let policy_file = unsafe { CStr::from_ptr(policy_file) };
+    let adapter = FileAdapter::new(policy_file.to_str().unwrap());
+    let e = block_on(Enforcer::new(Box::new(m), Box::new(adapter))).unwrap();
+
+    Box::new(e)
+}
+
+#[no_mangle]
+pub extern "C" fn enforce(
+    enforcer: &mut Enforcer,
+    sub: *const c_char,
+    obj: *const c_char,
+    act: *const c_char,
+) -> bool {
+    let sub = unsafe { CStr::from_ptr(sub) };
+    let obj = unsafe { CStr::from_ptr(obj) };
+    let act = unsafe { CStr::from_ptr(act) };
+    enforcer
+        .enforce(vec![
+            sub.to_str().unwrap(),
+            obj.to_str().unwrap(),
+            act.to_str().unwrap(),
+        ])
+        .unwrap()
+}

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -1,5 +1,5 @@
 use crate::{DefaultModel, Enforcer, FileAdapter};
-use futures::executor::block_on;
+use async_std::task::block_on;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,0 +1,1 @@
+pub mod c;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod util;
 mod watcher;
 
 pub mod error;
+pub mod ffi;
 pub mod prelude;
 
 pub use adapter::{Adapter, FileAdapter, MemoryAdapter};


### PR DESCRIPTION
Writing a pure C version casbin is quite difficult, but using rust ffi can be very easy. This commit adds C-bindings, so C/C++ programmer can easily integrate casbin into their projects.