### PR TITLE
remove clones and string allocs, use macro for model retreval

### DIFF
--- a/src/adapter/file_adapter.rs
+++ b/src/adapter/file_adapter.rs
@@ -28,13 +28,16 @@ use tokio::{
 
 use async_trait::async_trait;
 
-pub struct FileAdapter<P: AsRef<Path>> {
-    pub file_path: P,
+pub struct FileAdapter<P> {
+    file_path: P,
 }
 
 type LoadPolicyFileHandler = fn(String, &mut dyn Model);
 
-impl<P: AsRef<Path> + Send + Sync + 'static> FileAdapter<P> {
+impl<P> FileAdapter<P>
+where
+    P: AsRef<Path> + Send + Sync,
+{
     pub fn new(p: P) -> FileAdapter<P> {
         FileAdapter { file_path: p }
     }
@@ -61,7 +64,10 @@ impl<P: AsRef<Path> + Send + Sync + 'static> FileAdapter<P> {
 }
 
 #[async_trait]
-impl<P: AsRef<Path> + Send + Sync + 'static> Adapter for FileAdapter<P> {
+impl<P> Adapter for FileAdapter<P>
+where
+    P: AsRef<Path> + Send + Sync,
+{
     async fn load_policy(&self, m: &mut dyn Model) -> Result<()> {
         self.load_policy_file(m, load_policy_line).await?;
         Ok(())
@@ -103,7 +109,7 @@ impl<P: AsRef<Path> + Send + Sync + 'static> Adapter for FileAdapter<P> {
     }
 
     async fn add_policy(&mut self, _sec: &str, _ptype: &str, _rule: Vec<String>) -> Result<bool> {
-        // this api shouldn't implement, just for convinent
+        // this api shouldn't implement, just for convenience
         Ok(true)
     }
 
@@ -113,7 +119,7 @@ impl<P: AsRef<Path> + Send + Sync + 'static> Adapter for FileAdapter<P> {
         _ptype: &str,
         _rules: Vec<Vec<String>>,
     ) -> Result<bool> {
-        // this api shouldn't implement, just for convinent
+        // this api shouldn't implement, just for convenience
         Ok(true)
     }
 
@@ -123,7 +129,7 @@ impl<P: AsRef<Path> + Send + Sync + 'static> Adapter for FileAdapter<P> {
         _ptype: &str,
         _rule: Vec<String>,
     ) -> Result<bool> {
-        // this api shouldn't implement, just for convinent
+        // this api shouldn't implement, just for convenience
         Ok(true)
     }
 
@@ -133,7 +139,7 @@ impl<P: AsRef<Path> + Send + Sync + 'static> Adapter for FileAdapter<P> {
         _ptype: &str,
         _rule: Vec<Vec<String>>,
     ) -> Result<bool> {
-        // this api shouldn't implement, just for convinent
+        // this api shouldn't implement, just for convenience
         Ok(true)
     }
 
@@ -144,7 +150,7 @@ impl<P: AsRef<Path> + Send + Sync + 'static> Adapter for FileAdapter<P> {
         _field_index: usize,
         _field_values: Vec<String>,
     ) -> Result<bool> {
-        // this api shouldn't implement, just for convinent
+        // this api shouldn't implement, just for convenience
         Ok(true)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,8 +132,7 @@ impl Config {
         }
     }
 
-    pub(crate) fn add_config(&mut self, section: String, option: String, value: String) {
-        let mut section = section;
+    pub(crate) fn add_config(&mut self, mut section: String, option: String, value: String) {
         if section.is_empty() {
             section = DEFAULT_SECTION.to_owned();
         }


### PR DESCRIPTION
In the `FileAdapter` when the method is unimplemented like `add_policy` instead of returning `Ok(true)` would false be a better signal or even `panic!("this is not available for 'FileAdapter')` maybe?