### PR TITLE
upgrade rhai to 0.11.1 to make Error Send, Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ after_success: |
     docker run --security-opt seccomp=unconfined -v "$PWD:/volume" xd009642/tarpaulin sh -c "cargo tarpaulin --out Xml"
     bash <(curl -s https://codecov.io/bash)
 
-    if [[ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ]]; then
+    if [[ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ]] && [[ "$TRAVIS_PULL_REQUEST" != false ]]; then
       REMOTE_URL="$(git config --get remote.origin.url)";
       # Clone the repository fresh..for some reason checking out master fails
       # from a normal PR build's provided directory

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["auth", "authorization", "rbac", "acl", "abac"]
 
 [dependencies]
 regex = "1.3.1"
-rhai = "0.9.1"
+rhai = { version = "0.11.1", features = ["sync"] }
 ip_network = "0.3.4"
 ttl_cache = "0.5.1"
 emitbrown = "0.1.9"

--- a/src/adapter/memory_adapter.rs
+++ b/src/adapter/memory_adapter.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 
 #[derive(Default)]
 pub struct MemoryAdapter {
-    pub policy: IndexSet<Vec<String>>,
+    policy: IndexSet<Vec<String>>,
 }
 
 #[async_trait]

--- a/src/cached_enforcer.rs
+++ b/src/cached_enforcer.rs
@@ -104,3 +104,22 @@ impl DerefMut for CachedEnforcer {
         &mut self.enforcer
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_send<T: Send>() -> bool {
+        true
+    }
+
+    fn is_sync<T: Sync>() -> bool {
+        true
+    }
+
+    #[test]
+    fn test_send_sync() {
+        assert!(is_send::<CachedEnforcer>());
+        assert!(is_sync::<CachedEnforcer>());
+    }
+}

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -13,7 +13,7 @@ pub(crate) enum Event {
 
 lazy_static! {
     pub(crate) static ref EMITTER: Mutex<Emitter<'static, Event, Enforcer>> =
-        { Mutex::new(Emitter::new()) };
+        Mutex::new(Emitter::new());
     pub(crate) static ref CACHED_EMITTER: Mutex<Emitter<'static, Event, CachedEnforcer>> =
-        { Mutex::new(Emitter::new()) };
+        Mutex::new(Emitter::new());
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,3 +85,22 @@ impl Display for Error {
     }
 }
 impl StdError for Error {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_send<T: Send>() -> bool {
+        true
+    }
+
+    fn is_sync<T: Sync>() -> bool {
+        true
+    }
+
+    #[test]
+    fn test_send_sync() {
+        assert!(is_send::<Error>());
+        assert!(is_sync::<Error>());
+    }
+}

--- a/src/model/function_map.rs
+++ b/src/model/function_map.rs
@@ -4,7 +4,7 @@ use globset::GlobBuilder;
 
 use ip_network::IpNetwork;
 use regex::Regex;
-use rhai::Any;
+use rhai::Array;
 
 use std::collections::HashMap;
 #[cfg(feature = "runtime-tokio")]
@@ -78,7 +78,7 @@ fn key_match3(key1: String, key2: String) -> bool {
 // in_match determines whether key1 matches any element in key2
 // For example, in_match("alice", ["bob", "alice"]) returns true
 // Todo: add in operator in rhai and remove this
-pub fn in_match(k1: String, k2: Vec<Box<dyn Any>>) -> bool {
+pub fn in_match(k1: String, k2: Array) -> bool {
     let r = k2
         .into_iter()
         .filter_map(|x| x.downcast_ref::<String>().map(|y| y.to_owned()))


### PR DESCRIPTION
This PR

Adds

- Enforcer::get_adapter
- Enforcer::get_mut_adapter
- Enforcer::save_policy  => for periodically calling for saving policies into adapter because auto_save doesn't work for FileAdapter

Improves

- Enforcer::set_model => let it accepts `TryIntoModel` bound
- Enforcer::set_adapter => let it accepts `TryIntoAdapter` bound
- upgrade rhai to 0.11.1 to make sure `casbin::Error` is Send and Sync