### PR TITLE
Improve/watcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ regex = "1.3.1"
 rhai = { version = "0.11.1", features = ["sync"] }
 ip_network = "0.3.4"
 ttl_cache = "0.5.1"
-emitbrown = "0.1.9"
 lazy_static = "1.4.0"
 indexmap = "1.3.1"
 async-std = { version = "1.5.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casbin"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Joey <joey.xf@gmail.com>", "Cheng JIANG <jiang.cheng@vip.163.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this package to `Cargo.toml` of your project. (Check https://crates.io/crate
 
 ```toml
 [dependencies]
-casbin = "0.5.0"
+casbin = "0.5.1"
 async-std = { version = "1.5.0", features = ["attributes"] }
 ```
 
@@ -40,8 +40,9 @@ async-std = { version = "1.5.0", features = ["attributes"] }
 use casbin::prelude::*;
 
 #[async_std::main]
-async fn main() {
+async fn main() -> Result<()> {
     let mut e = Enforcer::new("path/to/model.conf", "path/to/policy.csv").await?;
+    Ok(())
 }
 ```
 

--- a/src/cached_api.rs
+++ b/src/cached_api.rs
@@ -3,6 +3,7 @@ use crate::cache::Cache;
 use std::time::Duration;
 
 pub trait CachedApi: Sized + Send + Sync {
+    fn get_mut_cache(&mut self) -> &mut dyn Cache<Vec<String>, bool>;
     fn set_cache(&mut self, cache: Box<dyn Cache<Vec<String>, bool>>);
     fn set_ttl(&mut self, ttl: Duration);
     fn set_capacity(&mut self, cap: usize);

--- a/src/cached_enforcer.rs
+++ b/src/cached_enforcer.rs
@@ -31,7 +31,7 @@ pub struct CachedEnforcer {
 
 impl EventEmitter<Event> for CachedEnforcer {
     fn on(&mut self, e: Event, f: fn(&mut Self, Option<EventData>)) {
-        self.events.entry(e).or_insert_with(|| vec![]).push(f)
+        self.events.entry(e).or_insert_with(|| Vec::new()).push(f)
     }
 
     fn off(&mut self, e: Event) {

--- a/src/cached_enforcer.rs
+++ b/src/cached_enforcer.rs
@@ -21,15 +21,17 @@ use std::{
     time::Duration,
 };
 
+type EventCallback = fn(&mut CachedEnforcer, Option<EventData>);
+
 pub struct CachedEnforcer {
     pub(crate) enforcer: Enforcer,
     pub(crate) cache: Box<dyn Cache<Vec<String>, bool>>,
-    pub(crate) events: HashMap<Event, Vec<fn(&mut Self, Option<EventData>)>>,
+    pub(crate) events: HashMap<Event, Vec<EventCallback>>,
 }
 
 impl EventEmitter<Event> for CachedEnforcer {
     fn on(&mut self, e: Event, f: fn(&mut Self, Option<EventData>)) {
-        self.events.entry(e).or_insert(vec![]).push(f)
+        self.events.entry(e).or_insert_with(|| vec![]).push(f)
     }
 
     fn off(&mut self, e: Event) {

--- a/src/cached_enforcer.rs
+++ b/src/cached_enforcer.rs
@@ -31,7 +31,7 @@ pub struct CachedEnforcer {
 
 impl EventEmitter<Event> for CachedEnforcer {
     fn on(&mut self, e: Event, f: fn(&mut Self, Option<EventData>)) {
-        self.events.entry(e).or_insert_with(|| Vec::new()).push(f)
+        self.events.entry(e).or_insert_with(Vec::new).push(f)
     }
 
     fn off(&mut self, e: Event) {

--- a/src/core_api.rs
+++ b/src/core_api.rs
@@ -13,6 +13,8 @@ pub trait CoreApi: Sized + Send + Sync {
     fn get_adapter(&self) -> &dyn Adapter;
     fn get_mut_adapter(&mut self) -> &mut dyn Adapter;
     fn set_watcher(&mut self, w: Box<dyn Watcher>);
+    fn get_watcher(&self) -> Option<&dyn Watcher>;
+    fn get_mut_watcher(&mut self) -> Option<&mut dyn Watcher>;
     fn get_role_manager(&self) -> Arc<RwLock<dyn RoleManager>>;
     fn set_role_manager(&mut self, rm: Arc<RwLock<dyn RoleManager>>);
     fn add_matching_fn(&mut self, f: fn(String, String) -> bool) -> Result<()>;

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -1,18 +1,53 @@
-use crate::{cached_enforcer::CachedEnforcer, enforcer::Enforcer};
+use crate::{cached_api::CachedApi, core_api::CoreApi};
 
-use emitbrown::Emitter;
-use lazy_static::lazy_static;
-
-use std::sync::Mutex;
+use std::hash::Hash;
 
 #[derive(Hash, PartialEq, Eq)]
-pub(crate) enum Event {
+pub enum Event {
     PolicyChange,
 }
 
-lazy_static! {
-    pub(crate) static ref EMITTER: Mutex<Emitter<'static, Event, Enforcer>> =
-        Mutex::new(Emitter::new());
-    pub(crate) static ref CACHED_EMITTER: Mutex<Emitter<'static, Event, CachedEnforcer>> =
-        Mutex::new(Emitter::new());
+pub fn notify_watcher<T: CoreApi>(e: &mut T, d: Option<EventData>) {
+    if let Some(w) = e.get_mut_watcher() {
+        w.update(d);
+    }
+}
+
+pub fn clear_cache<T: CoreApi + CachedApi>(ce: &mut T, _d: Option<EventData>) {
+    #[cfg(feature = "runtime-tokio")]
+    {
+        tokio::runtime::Builder::new()
+            .basic_scheduler()
+            .threaded_scheduler()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async { ce.get_mut_cache().clear().await });
+    }
+
+    #[cfg(feature = "runtime-async-std")]
+    {
+        async_std::task::block_on(async { ce.get_mut_cache().clear().await });
+    }
+}
+
+pub trait EventKey: Hash + PartialEq + Eq + Send + Sync {}
+impl<T> EventKey for T where T: Hash + PartialEq + Eq + Send + Sync {}
+
+#[derive(Clone)]
+pub enum EventData {
+    AddPolicy(Vec<String>),
+    AddPolicies(Vec<Vec<String>>),
+    RemovePolicy(Vec<String>),
+    RemovePolicies(Vec<Vec<String>>),
+    RemoveFilteredPolicy,
+}
+
+pub trait EventEmitter<K>
+where
+    K: EventKey,
+{
+    fn on(&mut self, e: K, f: fn(&mut Self, Option<EventData>));
+    fn off(&mut self, e: K);
+    fn emit(&mut self, e: K, d: Option<EventData>);
 }

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -53,6 +53,8 @@ macro_rules! generate_g_function {
     }};
 }
 
+type EventCallback = fn(&mut Enforcer, Option<EventData>);
+
 /// Enforcer is the main interface for authorization enforcement and policy management.
 pub struct Enforcer {
     pub(crate) model: Box<dyn Model>,
@@ -64,12 +66,12 @@ pub struct Enforcer {
     pub(crate) auto_save: bool,
     pub(crate) auto_build_role_links: bool,
     pub(crate) watcher: Option<Box<dyn Watcher>>,
-    pub(crate) events: HashMap<Event, Vec<fn(&mut Self, Option<EventData>)>>,
+    pub(crate) events: HashMap<Event, Vec<EventCallback>>,
 }
 
 impl EventEmitter<Event> for Enforcer {
     fn on(&mut self, e: Event, f: fn(&mut Self, Option<EventData>)) {
-        self.events.entry(e).or_insert(vec![]).push(f)
+        self.events.entry(e).or_insert_with(|| vec![]).push(f)
     }
 
     fn off(&mut self, e: Event) {

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -71,7 +71,7 @@ pub struct Enforcer {
 
 impl EventEmitter<Event> for Enforcer {
     fn on(&mut self, e: Event, f: fn(&mut Self, Option<EventData>)) {
-        self.events.entry(e).or_insert_with(|| Vec::new()).push(f)
+        self.events.entry(e).or_insert_with(Vec::new).push(f)
     }
 
     fn off(&mut self, e: Event) {

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -71,7 +71,7 @@ pub struct Enforcer {
 
 impl EventEmitter<Event> for Enforcer {
     fn on(&mut self, e: Event, f: fn(&mut Self, Option<EventData>)) {
-        self.events.entry(e).or_insert_with(|| vec![]).push(f)
+        self.events.entry(e).or_insert_with(|| Vec::new()).push(f)
     }
 
     fn off(&mut self, e: Event) {

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -202,16 +202,19 @@ impl CoreApi for Enforcer {
     /// use casbin::prelude::*;
     /// #[cfg(feature = "runtime-async-std")]
     /// #[async_std::main]
-    /// async fn main() {
-    ///     let mut e = Enforcer::new("examples/basic_model.conf", "examples/basic_policy.csv").await.unwrap();
-    ///     assert_eq!(true, e.enforce(&["alice", "data1", "read"]).await.unwrap());
+    /// async fn main() -> Result<()> {
+    ///     let mut e = Enforcer::new("examples/basic_model.conf", "examples/basic_policy.csv").await?;
+    ///     assert_eq!(true, e.enforce(&["alice", "data1", "read"]).await?);
+    ///     Ok(())
     /// }
     ///
     /// #[cfg(feature = "runtime-tokio")]
     /// #[tokio::main]
-    /// async fn main() {
-    ///     let mut e = Enforcer::new("examples/basic_model.conf", "examples/basic_policy.csv").await.unwrap();
-    ///     assert_eq!(true, e.enforce(&["alice", "data1", "read"]).await.unwrap());
+    /// async fn main() -> Result<()> {
+    ///     let mut e = Enforcer::new("examples/basic_model.conf", "examples/basic_policy.csv").await?;
+    ///     assert_eq!(true, e.enforce(&["alice", "data1", "read"]).await?);
+    ///
+    ///     Ok(())
     /// }
     /// #[cfg(all(not(feature = "runtime-async-std"), not(feature = "runtime-tokio")))]
     /// fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub use cached_enforcer::CachedEnforcer;
 pub use convert::{TryIntoAdapter, TryIntoModel};
 pub use core_api::CoreApi;
 pub use effector::{DefaultEffector, EffectKind, Effector};
+pub use emitter::EventData;
 pub use enforcer::Enforcer;
 pub use error::Error;
 pub use internal_api::InternalApi;

--- a/src/model/function_map.rs
+++ b/src/model/function_map.rs
@@ -29,6 +29,7 @@ impl Default for FunctionMap {
 }
 
 impl FunctionMap {
+    #[inline]
     pub fn add_function(&mut self, fname: &str, f: fn(String, String) -> bool) {
         self.fm.insert(fname.to_owned(), f);
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,8 +1,9 @@
-use crate::rbac::RoleManager;
-use crate::Result;
+use crate::{rbac::RoleManager, Result};
 
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 mod assertion;
 mod default_model;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,5 @@
 pub use crate::{
-    CachedApi, CachedEnforcer, CoreApi, DefaultModel, Enforcer, FileAdapter, InternalApi,
-    MemoryAdapter, MgmtApi, Model, RbacApi,
+    CachedApi, CachedEnforcer, CoreApi, DefaultModel, Enforcer, EventData, FileAdapter,
+    InternalApi, MemoryAdapter, MgmtApi, Model, RbacApi, Result, TryIntoAdapter, TryIntoModel,
+    Watcher,
 };

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,4 +1,6 @@
+use crate::emitter::EventData;
+
 pub trait Watcher: Send + Sync {
     fn set_update_callback(&mut self, cb: Box<dyn FnMut() + Send + Sync>);
-    fn update(&mut self);
+    fn update(&mut self, d: Option<EventData>);
 }


### PR DESCRIPTION
This PR
1. removes the usage of `emitbrown`, and implement EventEmitter for every Enforcer instance. 
2. include changes' details in watcher update functions