### PR TITLE
Add workflow for benchmark.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  benchmark:
+    name: Run Rust benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup toolchain update nightly && rustup default nightly
+      - name: Run benchmark
+        run: cargo +nightly bench | tee output.txt
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          name: Rust Benchmark
+          tool: 'cargo'
+          output-file-path: output.txt
+          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
+          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@GopherJ'

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -34,4 +34,4 @@ jobs:
                 deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
                 publish_branch: gh-pages
                 publish_dir: ./target/doc
-                force_orphan: true
+                keep_files: true


### PR DESCRIPTION
Added support for benchmark charts, please enjoy it.

**Usage**:

Need a new GitHub token that can read and write repo, and add it to [secrets](https://github.com/casbin/casbin-rs/settings/secrets/new) as a `PERSONAL_GITHUB_TOKEN`.

May see it at https://casbin.github.io/casbin-rs/dev/bench

**Example**:

See Online Example -> https://psiace.me/loge/dev/bench/

**FAQ**

Why change `force_orphan: true` to `keep_files: true`?

- I believe this will ensure that our document builds will never erase the benchmark history.

**Credit**

- https://github.com/rhysd/github-action-benchmark/

**Expect**

Close #104 
