### PR TITLE
Improve/benchmark

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -113,20 +113,30 @@ fn b_benchmark_rbac_model_small(b: &mut Bencher) {
     e.enable_auto_build_role_links(false);
 
     // 100 roles, 10 resources.
-    for i in 0..100 {
-        await_future(e.add_policy(vec![
-            format!("group{}", i),
-            format!("data{}", i / 10),
-            "read".to_owned(),
-        ]))
-        .unwrap();
-    }
+    await_future(
+        e.add_policies(
+            (0..100_u64)
+                .map(|i| {
+                    vec![
+                        format!("group{}", i),
+                        format!("data{}", i / 10),
+                        "read".to_owned(),
+                    ]
+                })
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
 
     // 1000 users.
-    for i in 0..1000 {
-        await_future(e.add_grouping_policy(vec![format!("user{}", i), format!("group{}", i / 10)]))
-            .unwrap();
-    }
+    await_future(
+        e.add_grouping_policies(
+            (0..1000)
+                .map(|i| vec![format!("user{}", i), format!("group{}", i / 10)])
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
 
     e.build_role_links().unwrap();
 
@@ -144,20 +154,30 @@ fn b_benchmark_cached_rbac_model_small(b: &mut Bencher) {
     e.enable_auto_build_role_links(false);
 
     // 100 roles, 10 resources.
-    for i in 0..100 {
-        await_future(e.add_policy(vec![
-            format!("group{}", i),
-            format!("data{}", i / 10),
-            "read".to_owned(),
-        ]))
-        .unwrap();
-    }
+    await_future(
+        e.add_policies(
+            (0..100_u64)
+                .map(|i| {
+                    vec![
+                        format!("group{}", i),
+                        format!("data{}", i / 10),
+                        "read".to_owned(),
+                    ]
+                })
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
 
     // 1000 users.
-    for i in 0..1000 {
-        await_future(e.add_grouping_policy(vec![format!("user{}", i), format!("group{}", i / 10)]))
-            .unwrap();
-    }
+    await_future(
+        e.add_grouping_policies(
+            (0..1000)
+                .map(|i| vec![format!("user{}", i), format!("group{}", i / 10)])
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
 
     e.build_role_links().unwrap();
 
@@ -175,20 +195,30 @@ fn b_benchmark_rbac_model_medium(b: &mut Bencher) {
     e.enable_auto_build_role_links(false);
 
     // 1000 roles, 100 resources.
-    for i in 0..1000 {
-        await_future(e.add_policy(vec![
-            format!("group{}", i),
-            format!("data{}", i / 10),
-            "read".to_owned(),
-        ]))
-        .unwrap();
-    }
+    await_future(
+        e.add_policies(
+            (0..1000_u64)
+                .map(|i| {
+                    vec![
+                        format!("group{}", i),
+                        format!("data{}", i / 10),
+                        "read".to_owned(),
+                    ]
+                })
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
 
     // 10000 users.
-    for i in 0..10000 {
-        await_future(e.add_grouping_policy(vec![format!("user{}", i), format!("group{}", i / 10)]))
-            .unwrap();
-    }
+    await_future(
+        e.add_grouping_policies(
+            (0..10000)
+                .map(|i| vec![format!("user{}", i), format!("group{}", i / 10)])
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
 
     e.build_role_links().unwrap();
 
@@ -206,20 +236,30 @@ fn b_benchmark_cached_rbac_model_medium(b: &mut Bencher) {
     e.enable_auto_build_role_links(false);
 
     // 1000 roles, 100 resources.
-    for i in 0..1000 {
-        await_future(e.add_policy(vec![
-            format!("group{}", i),
-            format!("data{}", i / 10),
-            "read".to_owned(),
-        ]))
-        .unwrap();
-    }
+    await_future(
+        e.add_policies(
+            (0..1000_u64)
+                .map(|i| {
+                    vec![
+                        format!("group{}", i),
+                        format!("data{}", i / 10),
+                        "read".to_owned(),
+                    ]
+                })
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
 
     // 10000 users.
-    for i in 0..10000 {
-        await_future(e.add_grouping_policy(vec![format!("user{}", i), format!("group{}", i / 10)]))
-            .unwrap();
-    }
+    await_future(
+        e.add_grouping_policies(
+            (0..10000)
+                .map(|i| vec![format!("user{}", i), format!("group{}", i / 10)])
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
 
     e.build_role_links().unwrap();
 
@@ -237,20 +277,71 @@ fn b_benchmark_rbac_model_large(b: &mut Bencher) {
     e.enable_auto_build_role_links(false);
 
     // 10000 roles, 1000 resources.
-    for i in 0..10000 {
-        await_future(e.add_policy(vec![
-            format!("group{}", i),
-            format!("data{}", i / 10),
-            "read".to_owned(),
-        ]))
-        .unwrap();
-    }
+    await_future(
+        e.add_policies(
+            (0..10000_u64)
+                .map(|i| {
+                    vec![
+                        format!("group{}", i),
+                        format!("data{}", i / 10),
+                        "read".to_owned(),
+                    ]
+                })
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
 
     // 100000 users.
-    for i in 0..100000 {
-        await_future(e.add_grouping_policy(vec![format!("user{}", i), format!("group{}", i / 10)]))
-            .unwrap();
-    }
+    await_future(
+        e.add_grouping_policies(
+            (0..100000)
+                .map(|i| vec![format!("user{}", i), format!("group{}", i / 10)])
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
+
+    e.build_role_links().unwrap();
+
+    b.iter(|| await_future(e.enforce(&["user50001", "data1500", "read"])).unwrap());
+}
+
+#[bench]
+fn b_benchmark_cached_rbac_model_large(b: &mut Bencher) {
+    let mut e = await_future(CachedEnforcer::new(
+        "examples/rbac_model.conf",
+        None as Option<&str>,
+    ))
+    .unwrap();
+
+    e.enable_auto_build_role_links(false);
+
+    // 10000 roles, 1000 resources.
+    await_future(
+        e.add_policies(
+            (0..10000_u64)
+                .map(|i| {
+                    vec![
+                        format!("group{}", i),
+                        format!("data{}", i / 10),
+                        "read".to_owned(),
+                    ]
+                })
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
+
+    // 100000 users.
+    await_future(
+        e.add_grouping_policies(
+            (0..100000)
+                .map(|i| vec![format!("user{}", i), format!("group{}", i / 10)])
+                .collect::<Vec<Vec<String>>>(),
+        ),
+    )
+    .unwrap();
 
     e.build_role_links().unwrap();
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -192,7 +192,7 @@ fn b_benchmark_rbac_model_medium(b: &mut Bencher) {
 
     e.build_role_links().unwrap();
 
-    b.iter(|| await_future(e.enforce(&["user5001", "data150", "read"])).unwrap());
+    b.iter(|| await_future(e.enforce(&["user5001", "data15", "read"])).unwrap());
 }
 
 #[bench]

--- a/src/effector.rs
+++ b/src/effector.rs
@@ -10,7 +10,7 @@ pub enum EffectKind {
 }
 
 #[derive(Default)]
-pub struct DefaultEffector {}
+pub struct DefaultEffector;
 
 impl Effector for DefaultEffector {
     fn merge_effects(&self, expr: &str, effects: Vec<EffectKind>) -> bool {

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -241,14 +241,14 @@ impl CoreApi for Enforcer {
             );
         }
 
-        for (i, token) in r_ast.tokens.iter().enumerate() {
-            if rvals[i].as_ref().starts_with('{') && rvals[i].as_ref().ends_with('}') {
+        for (rtoken, rval) in r_ast.tokens.iter().zip(rvals.iter()) {
+            if rval.as_ref().starts_with('{') && rval.as_ref().ends_with('}') {
                 // if r_sub, r_obj or r_act is a json string, then we need to parse it into an object
                 // https://casbin.org/docs/en/abac#how-to-use-abac
-                let scope_exp = format!("const {} = #{};", token, rvals[i].as_ref());
+                let scope_exp = format!("const {} = #{};", rtoken, rval.as_ref());
                 engine.eval_with_scope::<()>(&mut scope, &scope_exp)?;
             } else {
-                scope.push_constant(token, rvals[i].as_ref().to_owned());
+                scope.push_constant(rtoken, rval.as_ref().to_owned());
             }
         }
 
@@ -279,8 +279,8 @@ impl CoreApi for Enforcer {
                     )
                     .into());
                 }
-                for (pi, ptoken) in p_ast.tokens.iter().enumerate() {
-                    scope.push_constant(ptoken, pvals[pi].to_owned());
+                for (ptoken, pval) in p_ast.tokens.iter().zip(pvals.iter()) {
+                    scope.push_constant(ptoken, pval.to_owned());
                 }
 
                 let eval_result = engine.eval_with_scope::<bool>(&mut scope, expstring)?;

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -235,6 +235,12 @@ impl CoreApi for Enforcer {
         let m_ast = get_or_err!(self, "m", ModelError::M, "matcher");
         let e_ast = get_or_err!(self, "e", ModelError::E, "effector");
 
+        if r_ast.tokens.len() != rvals.len() {
+            return Err(
+                RequestError::UnmatchRequestDefinition(r_ast.tokens.len(), rvals.len()).into(),
+            );
+        }
+
         for (i, token) in r_ast.tokens.iter().enumerate() {
             if rvals[i].as_ref().starts_with('{') && rvals[i].as_ref().ends_with('}') {
                 // if r_sub, r_obj or r_act is a json string, then we need to parse it into an object
@@ -261,15 +267,10 @@ impl CoreApi for Enforcer {
         let mut policy_effects: Vec<EffectKind> = vec![];
         let policies = self.model.get_policy("p", "p");
         let policy_len = policies.len();
+        let scope_size = scope.len();
+
         if policy_len != 0 {
             policy_effects = vec![EffectKind::Deny; policy_len];
-            if r_ast.tokens.len() != rvals.len() {
-                return Err(RequestError::UnmatchRequestDefinition(
-                    r_ast.tokens.len(),
-                    rvals.len(),
-                )
-                .into());
-            }
             for (i, pvals) in policies.iter().enumerate() {
                 if p_ast.tokens.len() != pvals.len() {
                     return Err(PolicyError::UnmatchPolicyDefinition(
@@ -285,6 +286,7 @@ impl CoreApi for Enforcer {
                 let eval_result = engine.eval_with_scope::<bool>(&mut scope, expstring)?;
                 if !eval_result {
                     policy_effects[i] = EffectKind::Indeterminate;
+                    scope.rewind(scope_size);
                     continue;
                 }
                 if let Some(j) = p_ast.tokens.iter().position(|x| x == "p_eft") {
@@ -299,6 +301,7 @@ impl CoreApi for Enforcer {
                 } else {
                     policy_effects[i] = EffectKind::Allow;
                 }
+                scope.rewind(scope_size);
                 if e_ast.value == "priority(p_eft) || deny" {
                     break;
                 }


### PR DESCRIPTION
I have no idea why `add_grouping_policy` in casbin-rs is sooooo slow.... I changed it to batch operations, it seems at least we don't need to wait so much time for a result.

need to inverstigate.