### PR TITLE
Stable filtered adapter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casbin"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Joey <joey.xf@gmail.com>", "Cheng JIANG <jiang.cheng@vip.163.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this package to `Cargo.toml` of your project. (Check https://crates.io/crate
 
 ```toml
 [dependencies]
-casbin = "0.5.2"
+casbin = "0.6.0"
 async-std = { version = "1.5.0", features = ["attributes"] }
 ```
 

--- a/examples/rbac_with_domains_policy.csv
+++ b/examples/rbac_with_domains_policy.csv
@@ -1,6 +1,6 @@
-p, admin, domain1, data1, read
-p, admin, domain1, data1, write
-p, admin, domain2, data2, read
-p, admin, domain2, data2, write
-g, alice, admin, domain1
-g, bob, admin, domain2
+p, admin,domain1,data1,read
+p, admin,domain1,data1,write
+p, admin,domain2,data2,read
+p, admin,domain2,data2,write
+g, alice,admin,domain1
+g, bob,admin,domain2

--- a/src/adapter/file_adapter.rs
+++ b/src/adapter/file_adapter.rs
@@ -242,5 +242,5 @@ fn load_filtered_policy_line(line: String, m: &mut dyn Model, f: &Filter) -> boo
         }
     }
 
-    return is_filtered;
+    is_filtered
 }

--- a/src/adapter/file_adapter.rs
+++ b/src/adapter/file_adapter.rs
@@ -39,7 +39,7 @@ where
         FileAdapter { file_path: p }
     }
 
-    pub async fn load_policy_file(
+    async fn load_policy_file(
         &self,
         m: &mut dyn Model,
         handler: LoadPolicyFileHandler,
@@ -53,7 +53,7 @@ where
         Ok(())
     }
 
-    pub async fn save_policy_file(&self, text: String) -> Result<()> {
+    async fn save_policy_file(&self, text: String) -> Result<()> {
         let mut file = File::create(&self.file_path).await?;
         file.write_all(text.as_bytes()).await?;
         Ok(())

--- a/src/adapter/file_adapter.rs
+++ b/src/adapter/file_adapter.rs
@@ -1,4 +1,9 @@
-use crate::{adapter::Adapter, error::ModelError, model::Model, Result};
+use crate::{
+    adapter::{Adapter, Filter},
+    error::ModelError,
+    model::Model,
+    Result,
+};
 
 #[cfg(feature = "runtime-async-std")]
 use async_std::{
@@ -27,16 +32,21 @@ use std::convert::AsRef;
 
 pub struct FileAdapter<P> {
     file_path: P,
+    is_filtered: bool,
 }
 
 type LoadPolicyFileHandler = fn(String, &mut dyn Model);
+type LoadFilteredPolicyFileHandler = fn(String, &mut dyn Model, f: &Filter) -> bool;
 
 impl<P> FileAdapter<P>
 where
     P: AsRef<Path> + Send + Sync,
 {
     pub fn new(p: P) -> FileAdapter<P> {
-        FileAdapter { file_path: p }
+        FileAdapter {
+            file_path: p,
+            is_filtered: false,
+        }
     }
 
     async fn load_policy_file(
@@ -53,6 +63,24 @@ where
         Ok(())
     }
 
+    async fn load_filtered_policy_file(
+        &self,
+        m: &mut dyn Model,
+        filter: Filter,
+        handler: LoadFilteredPolicyFileHandler,
+    ) -> Result<bool> {
+        let f = File::open(&self.file_path).await?;
+        let mut lines = BufReader::new(f).lines();
+
+        let mut is_filtered = false;
+        while let Some(line) = lines.next().await {
+            if handler(line?, m, &filter) {
+                is_filtered = true;
+            }
+        }
+        Ok(is_filtered)
+    }
+
     async fn save_policy_file(&self, text: String) -> Result<()> {
         let mut file = File::create(&self.file_path).await?;
         file.write_all(text.as_bytes()).await?;
@@ -67,6 +95,16 @@ where
 {
     async fn load_policy(&self, m: &mut dyn Model) -> Result<()> {
         self.load_policy_file(m, load_policy_line).await?;
+        Ok(())
+    }
+
+    async fn load_filtered_policy(&mut self, m: &mut dyn Model, f: Filter) -> Result<()> {
+        if self
+            .load_filtered_policy_file(m, f, load_filtered_policy_line)
+            .await?
+        {
+            self.is_filtered = true;
+        }
         Ok(())
     }
 
@@ -148,6 +186,10 @@ where
         // this api shouldn't implement, just for convenience
         Ok(true)
     }
+
+    fn is_filtered(&self) -> bool {
+        self.is_filtered
+    }
 }
 
 fn load_policy_line(line: String, m: &mut dyn Model) {
@@ -164,4 +206,41 @@ fn load_policy_line(line: String, m: &mut dyn Model) {
             }
         }
     }
+}
+
+fn load_filtered_policy_line(line: String, m: &mut dyn Model, f: &Filter) -> bool {
+    if line.is_empty() || line.starts_with('#') {
+        return false;
+    }
+    let tokens: Vec<String> = line.split(',').map(|x| x.trim().to_string()).collect();
+    let key = tokens[0].clone();
+
+    let mut is_filtered = false;
+    if let Some(sec) = key.chars().next().map(|x| x.to_string()) {
+        if &sec == "p" {
+            for (i, rule) in f.p.iter().enumerate() {
+                if !rule.is_empty() && rule != &tokens[i + 1] {
+                    is_filtered = true;
+                }
+            }
+        }
+
+        if &sec == "g" {
+            for (i, rule) in f.g.iter().enumerate() {
+                if !rule.is_empty() && rule != &tokens[i + 1] {
+                    is_filtered = true;
+                }
+            }
+        }
+
+        if !is_filtered {
+            if let Some(t1) = m.get_mut_model().get_mut(&sec) {
+                if let Some(t2) = t1.get_mut(&key) {
+                    t2.policy.insert(tokens[1..].to_vec());
+                }
+            }
+        }
+    }
+
+    return is_filtered;
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -8,13 +8,20 @@ pub use file_adapter::FileAdapter;
 pub use memory_adapter::MemoryAdapter;
 pub use null_adapter::NullAdapter;
 
-use crate::model::Model;
-use crate::Result;
+use crate::{model::Model, Result};
+
+#[derive(Clone)]
+pub struct Filter {
+    pub p: Vec<&'static str>,
+    pub g: Vec<&'static str>,
+}
 
 #[async_trait]
 pub trait Adapter: Send + Sync {
     async fn load_policy(&self, m: &mut dyn Model) -> Result<()>;
+    async fn load_filtered_policy(&mut self, m: &mut dyn Model, f: Filter) -> Result<()>;
     async fn save_policy(&mut self, m: &mut dyn Model) -> Result<()>;
+    fn is_filtered(&self) -> bool;
     async fn add_policy(&mut self, sec: &str, ptype: &str, rule: Vec<String>) -> Result<bool>;
     async fn add_policies(
         &mut self,

--- a/src/adapter/null_adapter.rs
+++ b/src/adapter/null_adapter.rs
@@ -1,4 +1,8 @@
-use crate::{adapter::Adapter, model::Model, Result};
+use crate::{
+    adapter::{Adapter, Filter},
+    model::Model,
+    Result,
+};
 
 use async_trait::async_trait;
 
@@ -7,6 +11,10 @@ pub struct NullAdapter;
 #[async_trait]
 impl Adapter for NullAdapter {
     async fn load_policy(&self, _m: &mut dyn Model) -> Result<()> {
+        Ok(())
+    }
+
+    async fn load_filtered_policy(&mut self, _m: &mut dyn Model, _f: Filter) -> Result<()> {
         Ok(())
     }
 
@@ -53,5 +61,9 @@ impl Adapter for NullAdapter {
         _field_values: Vec<String>,
     ) -> Result<bool> {
         Ok(true)
+    }
+
+    fn is_filtered(&self) -> bool {
+        false
     }
 }

--- a/src/cached_api.rs
+++ b/src/cached_api.rs
@@ -2,7 +2,7 @@ use crate::cache::Cache;
 
 use std::time::Duration;
 
-pub trait CachedApi: Sized + Send + Sync {
+pub trait CachedApi: Send + Sync {
     fn get_mut_cache(&mut self) -> &mut dyn Cache<Vec<String>, bool>;
     fn set_cache(&mut self, cache: Box<dyn Cache<Vec<String>, bool>>);
     fn set_ttl(&mut self, ttl: Duration);

--- a/src/cached_enforcer.rs
+++ b/src/cached_enforcer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    adapter::Adapter,
+    adapter::{Adapter, Filter},
     cache::{Cache, DefaultCache},
     cached_api::CachedApi,
     convert::{TryIntoAdapter, TryIntoModel},
@@ -153,6 +153,16 @@ impl CoreApi for CachedEnforcer {
     #[inline]
     async fn load_policy(&mut self) -> Result<()> {
         self.enforcer.load_policy().await
+    }
+
+    #[inline]
+    async fn load_filtered_policy(&mut self, f: Filter) -> Result<()> {
+        self.enforcer.load_filtered_policy(f).await
+    }
+
+    #[inline]
+    fn is_filtered(&self) -> bool {
+        self.enforcer.is_filtered()
     }
 
     #[inline]

--- a/src/core_api.rs
+++ b/src/core_api.rs
@@ -1,4 +1,6 @@
-use crate::{Adapter, Effector, Model, Result, RoleManager, TryIntoAdapter, TryIntoModel, Watcher};
+use crate::{
+    Adapter, Effector, Filter, Model, Result, RoleManager, TryIntoAdapter, TryIntoModel, Watcher,
+};
 
 use async_trait::async_trait;
 
@@ -24,6 +26,8 @@ pub trait CoreApi: Sized + Send + Sync {
     async fn enforce<S: AsRef<str> + Send + Sync>(&mut self, rvals: &[S]) -> Result<bool>;
     fn build_role_links(&mut self) -> Result<()>;
     async fn load_policy(&mut self) -> Result<()>;
+    async fn load_filtered_policy(&mut self, f: Filter) -> Result<()>;
+    fn is_filtered(&self) -> bool;
     async fn save_policy(&mut self) -> Result<()>;
     fn clear_policy(&mut self);
     fn enable_auto_save(&mut self, auto_save: bool);

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -17,6 +17,7 @@ pub enum EventData {
     RemovePolicy(Vec<String>),
     RemovePolicies(Vec<Vec<String>>),
     RemoveFilteredPolicy(Vec<Vec<String>>),
+    SavePolicy(Vec<Vec<String>>),
 }
 
 pub trait EventEmitter<K>

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    adapter::Adapter,
+    adapter::{Adapter, Filter},
     convert::{TryIntoAdapter, TryIntoModel},
     core_api::CoreApi,
     effector::{DefaultEffector, EffectKind, Effector},
@@ -120,7 +120,6 @@ impl CoreApi for Enforcer {
 
         e.on(Event::PolicyChange, notify_watcher);
 
-        // TODO: check filtered adapter, match over a implementor?
         e.load_policy().await?;
         Ok(e)
     }
@@ -342,22 +341,53 @@ impl CoreApi for Enforcer {
         Ok(())
     }
 
+    async fn load_filtered_policy(&mut self, f: Filter) -> Result<()> {
+        self.model.clear_policy();
+        self.adapter
+            .load_filtered_policy(&mut *self.model, f)
+            .await?;
+
+        if self.auto_build_role_links {
+            self.build_role_links()?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn is_filtered(&self) -> bool {
+        self.adapter.is_filtered()
+    }
+
     async fn save_policy(&mut self) -> Result<()> {
+        if self.is_filtered() {
+            panic!("cannot save filtered policy");
+        }
+
         self.adapter.save_policy(&mut *self.model).await?;
 
-        let mut policies = self.get_model().get_policy("p", "p");
+        let mut policies: Vec<Vec<String>> = self
+            .get_model()
+            .get_policy("p", "p")
+            .into_iter()
+            .map(|mut x| {
+                x.insert(0, "p".to_owned());
+                x
+            })
+            .collect();
+
         if let Some(ast_map) = self.get_model().get_model().get("g") {
             for (ptype, ast) in ast_map {
-                policies.extend(
-                    ast.get_policy()
-                        .clone()
-                        .into_iter()
-                        .map(|mut x| {
-                            x.insert(0, ptype.clone());
-                            x
-                        })
-                        .collect::<Vec<Vec<String>>>(),
-                );
+                let gpolicies: Vec<Vec<String>> = ast
+                    .get_policy()
+                    .clone()
+                    .into_iter()
+                    .map(|mut x| {
+                        x.insert(0, ptype.clone());
+                        x
+                    })
+                    .collect();
+
+                policies.extend(gpolicies);
             }
         }
 
@@ -1108,5 +1138,68 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    #[cfg_attr(feature = "runtime-async-std", async_std::test)]
+    #[cfg_attr(feature = "runtime-tokio", tokio::test)]
+    async fn test_filtered_file_adapter() {
+        let mut e = Enforcer::new(
+            "examples/rbac_with_domains_model.conf",
+            "examples/rbac_with_domains_policy.csv",
+        )
+        .await
+        .unwrap();
+
+        let filter = Filter {
+            p: vec!["", "domain1"],
+            g: vec!["", "", "domain1"],
+        };
+
+        e.load_filtered_policy(filter).await.unwrap();
+        assert!(e
+            .enforce(&["alice", "domain1", "data1", "read"])
+            .await
+            .unwrap());
+        assert!(e
+            .enforce(&["alice", "domain1", "data1", "write"])
+            .await
+            .unwrap());
+        assert!(!e
+            .enforce(&["alice", "domain1", "data2", "read"])
+            .await
+            .unwrap());
+        assert!(!e
+            .enforce(&["alice", "domain1", "data2", "write"])
+            .await
+            .unwrap());
+        assert!(!e
+            .enforce(&["bob", "domain2", "data2", "read"])
+            .await
+            .unwrap());
+        assert!(!e
+            .enforce(&["bob", "domain2", "data2", "write"])
+            .await
+            .unwrap());
+    }
+
+    #[cfg_attr(feature = "runtime-async-std", async_std::test)]
+    #[cfg_attr(feature = "runtime-tokio", tokio::test)]
+    #[should_panic]
+    async fn test_filtered_file_adapter_save_policy() {
+        let mut e = Enforcer::new(
+            "examples/rbac_with_domains_model.conf",
+            "examples/rbac_with_domains_policy.csv",
+        )
+        .await
+        .unwrap();
+
+        let filter = Filter {
+            p: vec!["", "domain1"],
+            g: vec!["", "", "domain1"],
+        };
+
+        e.save_policy().await.unwrap();
+        e.load_filtered_policy(filter).await.unwrap();
+        e.save_policy().await.unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod watcher;
 pub mod error;
 pub mod prelude;
 
-pub use adapter::{Adapter, FileAdapter, MemoryAdapter, NullAdapter};
+pub use adapter::{Adapter, FileAdapter, Filter, MemoryAdapter, NullAdapter};
 pub use cache::{Cache, DefaultCache};
 pub use cached_api::CachedApi;
 pub use cached_enforcer::CachedEnforcer;

--- a/src/model/assertion.rs
+++ b/src/model/assertion.rs
@@ -11,7 +11,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-pub(crate) type AssertionMap = HashMap<String, Assertion>;
+pub type AssertionMap = HashMap<String, Assertion>;
 
 #[derive(Clone)]
 pub struct Assertion {
@@ -35,10 +35,12 @@ impl Default for Assertion {
 }
 
 impl Assertion {
+    #[inline]
     pub fn get_policy(&self) -> &IndexSet<Vec<String>> {
         &self.policy
     }
 
+    #[inline]
     pub fn get_mut_policy(&mut self) -> &mut IndexSet<Vec<String>> {
         &mut self.policy
     }

--- a/src/model/function_map.rs
+++ b/src/model/function_map.rs
@@ -8,7 +8,7 @@ use globset::GlobBuilder;
 use ip_network::IpNetwork;
 use regex::Regex;
 
-use std::collections::{hash_map::Iter, HashMap};
+use std::collections::HashMap;
 
 pub struct FunctionMap {
     pub(crate) fm: HashMap<String, fn(String, String) -> bool>,
@@ -35,7 +35,7 @@ impl FunctionMap {
     }
 
     #[inline]
-    pub fn get_functions(&self) -> Iter<'_, String, fn(String, String) -> bool> {
+    pub fn get_functions(&self) -> impl Iterator<Item = (&String, &fn(String, String) -> bool)> {
         self.fm.iter()
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -9,7 +9,7 @@ mod assertion;
 mod default_model;
 mod function_map;
 
-pub(crate) use assertion::{Assertion, AssertionMap};
+pub use assertion::{Assertion, AssertionMap};
 pub use default_model::DefaultModel;
 pub use function_map::*;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 pub use crate::{
-    CachedApi, CachedEnforcer, CoreApi, DefaultModel, Enforcer, EventData, FileAdapter,
+    CachedApi, CachedEnforcer, CoreApi, DefaultModel, Enforcer, EventData, FileAdapter, Filter,
     InternalApi, MemoryAdapter, MgmtApi, Model, NullAdapter, RbacApi, Result, TryIntoAdapter,
     TryIntoModel, Watcher,
 };

--- a/src/rbac_api.rs
+++ b/src/rbac_api.rs
@@ -199,22 +199,16 @@ where
     }
 
     async fn delete_user(&mut self, name: &str) -> Result<bool> {
-        self.remove_filtered_grouping_policy(
-            0,
-            vec![name].iter().map(|s| (*s).to_string()).collect(),
-        )
-        .await
+        self.remove_filtered_grouping_policy(0, vec![name.to_string()])
+            .await
     }
 
     async fn delete_role(&mut self, name: &str) -> Result<bool> {
         let res1 = self
-            .remove_filtered_grouping_policy(
-                1,
-                vec![name].iter().map(|s| (*s).to_string()).collect(),
-            )
+            .remove_filtered_grouping_policy(1, vec![name.to_string()])
             .await?;
         let res2 = self
-            .remove_filtered_policy(0, vec![name].iter().map(|s| (*s).to_string()).collect())
+            .remove_filtered_policy(0, vec![name.to_string()])
             .await?;
         Ok(res1 || res2)
     }


### PR DESCRIPTION
This is a stable version of filtered adapter, I merged both FilteredAdapter and Adapter into one trait because rust is strongly typed and doesn't support dynamic casting.

The disadvantage of this is: this PR will break `diesel-adapter` and `sqlx-adapter`, we will need to implement

```rust
async fn load_filtered_policy(&mut self, m: &mut dyn Model, f: Filter) -> Result<()>;
 fn is_filtered(&self) -> bool;
```

for them.

@xcaptain  pls see if you like this better