### PR TITLE
POC try scaling abac rules

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,18 +1,24 @@
 use lazy_static::lazy_static;
 use regex::Regex;
+use rhai::Scope;
+
+macro_rules! regex {
+    ($re:expr) => {
+        ::regex::Regex::new($re).unwrap()
+    };
+}
+
+lazy_static! {
+    static ref ESC_A: Regex = regex!(r"(r|p)\.");
+    static ref ESC_G: Regex = regex!(r"(g\d*)\(((?:\s*[r|p]\.\w+\s*,\s*){1,2}\s*[r|p]\.\w+\s*)\)");
+    pub(crate) static ref ESC_E: Regex = regex!(r"eval\((?P<rule>[^),]*)\)");
+}
 
 pub fn escape_assertion(s: String) -> String {
-    lazy_static! {
-        static ref ASSERT: Regex = Regex::new(r"(r|p)\.").unwrap();
-    }
-    ASSERT.replace_all(&s, "${1}_").to_string()
+    ESC_A.replace_all(&s, "${1}_").to_string()
 }
 
 pub fn escape_g_function(s: String) -> String {
-    lazy_static! {
-        static ref ESC_G: Regex =
-            Regex::new(r"(g\d*)\(((?:\s*[r|p]\.\w+\s*,\s*){1,2}\s*[r|p]\.\w+\s*)\)").unwrap();
-    }
     ESC_G.replace_all(&s, "${1}([${2}])").to_string()
 }
 
@@ -21,28 +27,18 @@ pub fn remove_comments(mut s: String) -> String {
         s.truncate(idx);
     }
 
-    s.trim().to_owned()
+    s.trim_end().to_owned()
 }
 
-pub fn merge_abc_into_matcher(mut m: String, v: &str) -> String {
-    lazy_static! {
-        static ref RE: Regex = Regex::new(r"(.*)Any\(_\)(.*)").unwrap();
-        static ref RE_M: Regex = Regex::new(r"Any\((?P<rule>[^),]*)\)").unwrap();
-    }
-
-    for caps in RE_M.captures_iter(v) {
-        if !m.contains("Any(_)") {
-            break;
+pub fn escape_eval(mut m: String, scope: &Scope) -> String {
+    for caps in ESC_E.captures_iter(&m.to_owned()) {
+        if let Some(val) = scope.get_value::<String>(&caps["rule"]) {
+            m = ESC_E
+                .replace(m.as_str(), escape_assertion(format!("({})", &val)).as_str())
+                .to_string();
+        } else {
+            panic!("eval(*) must make sure * can be evaluated");
         }
-        m = RE
-            .replace_all(
-                m.as_str(),
-                escape_assertion(format!("$1({})$2", &caps["rule"])).as_str(),
-            )
-            .to_string();
-    }
-    if m.contains("Any(_)") {
-        panic!("abac placeholder in matcher doesn't match abac rule in policy");
     }
     m
 }
@@ -86,28 +82,5 @@ mod tests {
         let exp = "g(r_sub, p_sub) && r_obj == p_obj && r_act == p_act";
 
         assert_eq!(exp, escape_assertion(s.to_owned()));
-    }
-
-    #[test]
-    fn test_merge_abac_into_matcher() {
-        let m1 = r#"Any(_) && Any(_) && r_sub == "alice""#.to_owned();
-        let v1 = r#"Any(r.sub.age >= 18), Any(r.obj.Owner == r.sub.name), (GET|POST)"#;
-
-        assert_eq!(
-            merge_abc_into_matcher(m1, v1),
-            r#"(r_obj.Owner == r_sub.name) && (r_sub.age >= 18) && r_sub == "alice""#
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_merge_abac_into_matcher_panic() {
-        let m1 = r#"Any(_) && Any(_) && r.sub == "alice""#.to_owned();
-        let v1 = r#"Any(r.sub.age >= 18), /data1, (GET|POST)"#;
-
-        assert_eq!(
-            merge_abc_into_matcher(m1, v1),
-            r#"(r_sub.age >= 18) && r_sub == "alice""#
-        );
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,16 +2,11 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use rhai::Scope;
 
-macro_rules! regex {
-    ($re:expr) => {
-        ::regex::Regex::new($re).unwrap()
-    };
-}
-
 lazy_static! {
-    static ref ESC_A: Regex = regex!(r"(r|p)\.");
-    static ref ESC_G: Regex = regex!(r"(g\d*)\(((?:\s*[r|p]\.\w+\s*,\s*){1,2}\s*[r|p]\.\w+\s*)\)");
-    pub(crate) static ref ESC_E: Regex = regex!(r"eval\((?P<rule>[^),]*)\)");
+    static ref ESC_A: Regex = Regex::new(r"(r|p)\.").unwrap();
+    static ref ESC_G: Regex =
+        Regex::new(r"(g\d*)\(((?:\s*[r|p]\.\w+\s*,\s*){1,2}\s*[r|p]\.\w+\s*)\)").unwrap();
+    pub(crate) static ref ESC_E: Regex = Regex::new(r"eval\((?P<rule>[^),]*)\)").unwrap();
 }
 
 pub fn escape_assertion(s: String) -> String {
@@ -31,7 +26,8 @@ pub fn remove_comments(mut s: String) -> String {
 }
 
 pub fn escape_eval(mut m: String, scope: &Scope) -> String {
-    for caps in ESC_E.captures_iter(&m.to_owned()) {
+    let cloned_m = m.to_owned();
+    for caps in ESC_E.captures_iter(&cloned_m) {
         if let Some(val) = scope.get_value::<String>(&caps["rule"]) {
             m = ESC_E
                 .replace(m.as_str(), escape_assertion(format!("({})", &val)).as_str())


### PR DESCRIPTION
This PR allows to define in model some thing like this, I would like to solve: https://github.com/casbin/casbin/issues/354
```ini
[request_definition]
r = sub, obj, act

[policy_definition]
p = sub, obj, act

[policy_effect]
e = some(where (p.eft == allow))

[matchers]
m = Any(_) && r.obj == p.obj && r.act == p.act
```
and in policy we can then write like this:
```
p, Any(r.sub.age > 18), /data1, read
```
This policy means that we don't care who is the person sending request, but his/her age should be greater than 18

I made it works in casbin-rs, not sure if we should do like this but I think it may helps solving some problems.

Also can the syntax be better?