### PR TITLE
add enforce_with_matcher && make it possible to use p1..n in matcher && supports multiple matchers

### DIFF
--- a/src/core_api.rs
+++ b/src/core_api.rs
@@ -24,6 +24,11 @@ pub trait CoreApi: Sized + Send + Sync {
     async fn set_adapter<A: TryIntoAdapter>(&mut self, a: A) -> Result<()>;
     fn set_effector(&mut self, e: Box<dyn Effector>);
     async fn enforce<S: AsRef<str> + Send + Sync>(&mut self, rvals: &[S]) -> Result<bool>;
+    async fn enforce_with_matcher<S: AsRef<str> + Send + Sync>(
+        &mut self,
+        rvals: &[S],
+        m: &str,
+    ) -> Result<bool>;
     fn build_role_links(&mut self) -> Result<()>;
     async fn load_policy(&mut self) -> Result<()>;
     async fn load_filtered_policy(&mut self, f: Filter) -> Result<()>;

--- a/src/effector.rs
+++ b/src/effector.rs
@@ -1,5 +1,5 @@
 pub trait Effector: Send + Sync {
-    fn merge_effects(&self, expr: &str, effects: Vec<EffectKind>) -> bool;
+    fn merge_effects(&self, expr: &str, effects: &[EffectKind]) -> bool;
 }
 
 #[derive(PartialEq, Clone)]
@@ -13,11 +13,11 @@ pub enum EffectKind {
 pub struct DefaultEffector;
 
 impl Effector for DefaultEffector {
-    fn merge_effects(&self, expr: &str, effects: Vec<EffectKind>) -> bool {
+    fn merge_effects(&self, expr: &str, effects: &[EffectKind]) -> bool {
         if expr == "some(where (p_eft == allow))" {
             let mut result = false;
             for eft in effects {
-                if eft == EffectKind::Allow {
+                if eft == &EffectKind::Allow {
                     result = true;
                     break;
                 }
@@ -27,7 +27,7 @@ impl Effector for DefaultEffector {
         } else if expr == "!some(where (p_eft == deny))" {
             let mut result = true;
             for eft in effects {
-                if eft == EffectKind::Deny {
+                if eft == &EffectKind::Deny {
                     result = false;
                     break;
                 }
@@ -37,9 +37,9 @@ impl Effector for DefaultEffector {
         } else if expr == "some(where (p_eft == allow)) && !some(where (p_eft == deny))" {
             let mut result = false;
             for eft in effects {
-                if eft == EffectKind::Allow {
+                if eft == &EffectKind::Allow {
                     result = true;
-                } else if eft == EffectKind::Deny {
+                } else if eft == &EffectKind::Deny {
                     result = false;
                     break;
                 }
@@ -49,8 +49,8 @@ impl Effector for DefaultEffector {
         } else if expr == "priority(p_eft) || deny" {
             let mut result = false;
             for eft in effects {
-                if eft != EffectKind::Indeterminate {
-                    if eft == EffectKind::Allow {
+                if eft != &EffectKind::Indeterminate {
+                    if eft == &EffectKind::Allow {
                         result = true
                     } else {
                         result = false

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -39,7 +39,7 @@ macro_rules! get_or_err {
             .ok_or_else(|| {
                 Error::from($err(format!(
                     "Missing {}::{} section in conf file",
-                    $key1, $msg
+                    $msg, $key2
                 )))
             })?
     }};
@@ -271,7 +271,6 @@ impl CoreApi for Enforcer {
         let mut scope: Scope = Scope::new();
 
         let r_ast = get_or_err!(self, "r", "r", ModelError::R, "request");
-        let e_ast = get_or_err!(self, "e", "e", ModelError::E, "effector");
 
         let m_sec = get_or_err!(self, "m", ModelError::M, "matcher");
         let m_ast = get_or_err!(self, "m", m, ModelError::M, m);
@@ -307,6 +306,8 @@ impl CoreApi for Enforcer {
             .into_iter()
             .filter(|(k, _)| refs.contains(k) || k == &m)
         {
+            let e_ast = get_or_err!(self, "e", &m_k.replace("m", "e"), ModelError::E, "effector");
+
             let policy_effects = if let Some(ptype) = extract_ptype_from_matcher(&m_ast.value) {
                 let p_ast = get_or_err!(self, "p", &ptype, ModelError::P, &ptype);
 
@@ -1302,6 +1303,8 @@ mod tests {
         m.add_def("p", "p1", "sub_rule, obj, act");
         m.add_def("p", "p2", "sub_rule, obj, act");
         m.add_def("e", "e", "some(where (p.eft == allow))");
+        m.add_def("e", "e1", "some(where (p.eft == allow))");
+        m.add_def("e", "e2", "some(where (p.eft == allow))");
         m.add_def(
             "m",
             "m",

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -5,6 +5,7 @@ use crate::{
     effector::{DefaultEffector, EffectKind, Effector},
     emitter::{notify_watcher, Event, EventData, EventEmitter},
     error::{Error, ModelError, PolicyError, RequestError},
+    management_api::MgmtApi,
     model::{FunctionMap, Model},
     rbac::{DefaultRoleManager, RoleManager},
     util::{escape_eval, extract_ptype_from_matcher, ESC_E},
@@ -431,31 +432,10 @@ impl CoreApi for Enforcer {
 
         self.adapter.save_policy(&mut *self.model).await?;
 
-        let mut policies: Vec<Vec<String>> = self
-            .get_model()
-            .get_policy("p", "p")
-            .into_iter()
-            .map(|mut x| {
-                x.insert(0, "p".to_owned());
-                x
-            })
-            .collect();
+        let mut policies = self.get_all_policy();
+        let gpolicies = self.get_all_grouping_policy();
 
-        if let Some(ast_map) = self.get_model().get_model().get("g") {
-            for (ptype, ast) in ast_map {
-                let gpolicies: Vec<Vec<String>> = ast
-                    .get_policy()
-                    .clone()
-                    .into_iter()
-                    .map(|mut x| {
-                        x.insert(0, ptype.clone());
-                        x
-                    })
-                    .collect();
-
-                policies.extend(gpolicies);
-            }
-        }
+        policies.extend(gpolicies);
 
         self.emit(Event::PolicyChange, Some(EventData::SavePolicy(policies)));
         Ok(())

--- a/src/management_api.rs
+++ b/src/management_api.rs
@@ -98,6 +98,8 @@ pub trait MgmtApi: InternalApi {
         self.get_named_policy("p")
     }
 
+    fn get_all_policy(&self) -> Vec<Vec<String>>;
+
     fn get_named_policy(&self, ptype: &str) -> Vec<Vec<String>>;
 
     fn get_filtered_policy(
@@ -124,6 +126,8 @@ pub trait MgmtApi: InternalApi {
     fn get_grouping_policy(&self) -> Vec<Vec<String>> {
         self.get_named_grouping_policy("g")
     }
+
+    fn get_all_grouping_policy(&self) -> Vec<Vec<String>>;
 
     fn get_named_grouping_policy(&self, ptype: &str) -> Vec<Vec<String>>;
 
@@ -265,6 +269,20 @@ where
         self.get_model().get_policy("p", ptype)
     }
 
+    fn get_all_policy(&self) -> Vec<Vec<String>> {
+        let mut res: Vec<Vec<String>> = vec![];
+        if let Some(ast_map) = self.get_model().get_model().get("p") {
+            for (ptype, ast) in ast_map {
+                res.extend(ast.get_policy().clone().into_iter().map(|mut x| {
+                    x.insert(0, ptype.clone());
+                    x
+                }))
+            }
+        }
+
+        res
+    }
+
     fn get_filtered_named_policy(
         &self,
         ptype: &str,
@@ -281,6 +299,20 @@ where
 
     fn get_named_grouping_policy(&self, ptype: &str) -> Vec<Vec<String>> {
         self.get_model().get_policy("g", ptype)
+    }
+
+    fn get_all_grouping_policy(&self) -> Vec<Vec<String>> {
+        let mut res: Vec<Vec<String>> = vec![];
+        if let Some(ast_map) = self.get_model().get_model().get("g") {
+            for (ptype, ast) in ast_map {
+                res.extend(ast.get_policy().clone().into_iter().map(|mut x| {
+                    x.insert(0, ptype.clone());
+                    x
+                }))
+            }
+        }
+
+        res
     }
 
     fn get_filtered_named_grouping_policy(

--- a/src/model/assertion.rs
+++ b/src/model/assertion.rs
@@ -4,14 +4,11 @@ use crate::{
     Result,
 };
 
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::sync::{Arc, RwLock};
 
-pub type AssertionMap = HashMap<String, Assertion>;
+pub type AssertionMap = IndexMap<String, Assertion>;
 
 #[derive(Clone)]
 pub struct Assertion {

--- a/src/model/default_model.rs
+++ b/src/model/default_model.rs
@@ -7,7 +7,7 @@ use crate::{
     Result,
 };
 
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 
 #[cfg(feature = "runtime-async-std")]
 use async_std::path::Path;
@@ -120,7 +120,7 @@ impl Model for DefaultModel {
         if let Some(new_model) = self.model.get_mut(sec) {
             new_model.insert(key.to_owned(), ast);
         } else {
-            let mut new_ast_map = HashMap::new();
+            let mut new_ast_map = IndexMap::new();
             new_ast_map.insert(key.to_owned(), ast);
             self.model.insert(sec.to_owned(), new_ast_map);
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,10 +3,11 @@ use regex::Regex;
 use rhai::Scope;
 
 lazy_static! {
-    static ref ESC_A: Regex = Regex::new(r"(r|p)\.").unwrap();
+    static ref ESC_A: Regex = Regex::new(r"\b(r\d*|p\d*)\.").unwrap();
     static ref ESC_G: Regex =
-        Regex::new(r"(g\d*)\(((?:\s*[r|p]\.\w+\s*,\s*){1,2}\s*[r|p]\.\w+\s*)\)").unwrap();
-    pub(crate) static ref ESC_E: Regex = Regex::new(r"eval\((?P<rule>[^)]*)\)").unwrap();
+        Regex::new(r"\b(g\d*)\(((?:\s*[r|p]\d*\.\w+\s*,\s*){1,2}\s*[r|p]\d*\.\w+\s*)\)").unwrap();
+    pub(crate) static ref ESC_E: Regex = Regex::new(r"\beval\((?P<rule>[^)]*)\)").unwrap();
+    static ref EXR_P: Regex = Regex::new(r"\b(?P<ptype>p\d*)_").unwrap();
 }
 
 pub fn escape_assertion(s: String) -> String {
@@ -26,8 +27,8 @@ pub fn remove_comments(mut s: String) -> String {
 }
 
 pub fn escape_eval(mut m: String, scope: &Scope) -> String {
-    let cloned_m = m.to_owned();
-    for caps in ESC_E.captures_iter(&cloned_m) {
+    let cm = m.to_owned();
+    for caps in ESC_E.captures_iter(&cm) {
         if let Some(val) = scope.get_value::<String>(&caps["rule"]) {
             m = ESC_E
                 .replace(m.as_str(), escape_assertion(format!("({})", &val)).as_str())
@@ -37,6 +38,23 @@ pub fn escape_eval(mut m: String, scope: &Scope) -> String {
         }
     }
     m
+}
+
+pub fn extract_ptype_from_matcher(m: &str) -> Option<String> {
+    let mut ptype: Option<String> = None;
+
+    for caps in EXR_P.captures_iter(m) {
+        if ptype.is_none() {
+            ptype = Some(caps["ptype"].to_string());
+            continue;
+        } else if Some(&caps["ptype"]) == ptype.as_deref() {
+            continue;
+        } else {
+            panic!("one matcher can only contain one type of policy. eg. p, p2, p3...");
+        }
+    }
+
+    return ptype;
 }
 
 #[cfg(test)]
@@ -59,6 +77,11 @@ mod tests {
         let exp2 = "g3([r.sub, p.sub]) && r.obj == p.obj && r.act == p.act";
 
         assert_eq!(exp2, escape_g_function(s2.to_owned()));
+
+        let s3 = "g3(r2.sub, p2.sub) && r2.obj == p2.obj && r2.act == p2.act";
+        let exp3 = "g3([r2.sub, p2.sub]) && r2.obj == p2.obj && r2.act == p2.act";
+
+        assert_eq!(exp3, escape_g_function(s3.to_owned()));
     }
 
     #[test]
@@ -78,5 +101,29 @@ mod tests {
         let exp = "g(r_sub, p_sub) && r_obj == p_obj && r_act == p_act";
 
         assert_eq!(exp, escape_assertion(s.to_owned()));
+
+        let s1 = "g(r2.sub, p2.sub) && r2.obj == p2.obj && r2.act == p2.act";
+        let exp1 = "g(r2_sub, p2_sub) && r2_obj == p2_obj && r2_act == p2_act";
+
+        assert_eq!(exp1, escape_assertion(s1.to_owned()));
+    }
+
+    #[test]
+    fn test_extract_ptype() {
+        let m1 = "r_sub == p_sub";
+        assert!(extract_ptype_from_matcher(&m1) == Some("p".to_owned()));
+
+        let m2 = "r_sub == p3_sub";
+        assert!(extract_ptype_from_matcher(&m2) == Some("p3".to_owned()));
+
+        let m3 = "r_sub == ap3_sub";
+        assert!(extract_ptype_from_matcher(&m3) == None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_extract_ptype_panic() {
+        let m1 = "r_sub == p_sub && r_obj == p2_obj";
+        assert!(extract_ptype_from_matcher(&m1) == Some("p".to_owned()));
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -54,7 +54,7 @@ pub fn extract_ptype_from_matcher(m: &str) -> Option<String> {
         }
     }
 
-    return ptype;
+    ptype
 }
 
 #[cfg(test)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,7 @@ lazy_static! {
         Regex::new(r"\b(g\d*)\(((?:\s*[r|p]\d*\.\w+\s*,\s*){1,2}\s*[r|p]\d*\.\w+\s*)\)").unwrap();
     pub(crate) static ref ESC_E: Regex = Regex::new(r"\beval\((?P<rule>[^)]*)\)").unwrap();
     static ref EXR_P: Regex = Regex::new(r"\b(?P<ptype>p\d*)_").unwrap();
+    static ref EXR_R: Regex = Regex::new(r"\b(?P<matcher>m\d*)\b").unwrap();
 }
 
 pub fn escape_assertion(s: String) -> String {
@@ -55,6 +56,16 @@ pub fn extract_ptype_from_matcher(m: &str) -> Option<String> {
     }
 
     ptype
+}
+
+pub fn extract_ref_matchers(m: &str) -> Vec<String> {
+    let mut res: Vec<String> = vec![];
+
+    for caps in EXR_R.captures_iter(m) {
+        res.push(caps["matcher"].to_string());
+    }
+
+    res
 }
 
 #[cfg(test)]
@@ -125,5 +136,20 @@ mod tests {
     fn test_extract_ptype_panic() {
         let m1 = "r_sub == p_sub && r_obj == p2_obj";
         assert!(extract_ptype_from_matcher(&m1) == Some("p".to_owned()));
+    }
+
+    #[test]
+    fn test_extract_ref_matchers() {
+        let m1 = "m&&m1&& m2&& m3 &&m5 &&m6u";
+        assert_eq!(
+            extract_ref_matchers(m1),
+            vec![
+                "m".to_owned(),
+                "m1".to_owned(),
+                "m2".to_owned(),
+                "m3".to_owned(),
+                "m5".to_owned()
+            ]
+        );
     }
 }


### PR DESCRIPTION
This PR allows to use model like this:

```ini
[request_definition]
r = sub, obj, act

[policy_definition]
p = sub_rule, obj, act
p1 = sub_rule, obj, act
p2 = sub_rule, obj, act

[policy_effect]
e = some(where (p.eft == allow))

[matchers]
m = !eval(p.sub_rule) && r.obj == p.obj && r.act == p.act
m1 = eval(p1.sub_rule) && r.obj == p1.obj && r.act == p1.act
m2 = m && m1 && eval(p2.sub_rule) && r.obj == p2.obj && r.act == p2.act
```

then if we have the following policies:
```
// only m is using p, but we have ! before eval, so it's turning to
// only when one person's age <= 60, he/she will be able to read /ata1

p, r.sub.age > 60, /data1, read

// only m1 is using p1, if we use m1 for enforcing
// it allows people with age > 16 to read /data1

p1, r.sub.age > 16, /data1, read

// only m2 is using p2, if we use m2 for enforcing
// it allows people with age > 50 && <= 60 to read /data1
// why do we have <= 60 here ?
// because m && m1 means age <= 60 && age > 16
// plus the following policy
// it turns to age > 50 && age <= 60

p2, r.sub.age > 50, /data1, read
```

```rust
// authorized because 16 <= 60
e.enforce_with_matcher(&[r#"{"name": "alice", "age": 16}"#, "/data1", "read"], "m")

// denied because 70 > 60
e.enforce_with_matcher(&[r#"{"name": "alice", "age": 70}"#, "/data1", "read"], "m")

// authorized because 19 > 16
e.enforce_with_matcher(&[r#"{"name": "bob", "age": 19}"#, "/data1", "read"], "m1")

// denied because 15 < 16
e.enforce_with_matcher(&[r#"{"name": "bob", "age": 15}"#, "/data1", "read"], "m1")

// authorized because m && m1 means >16 && <= 60, plus p2
// it means > 50 && <= 60
e.enforce_with_matcher(&[r#"{"name": "bob", "age": 51}"#, "/data1", "read"], "m2")

// denied because 61 > 60
e.enforce_with_matcher(&[r#"{"name": "bob", "age": 61}"#, "/data1", "read"], "m2")
```

Here we will iterate all matchers, and extract `ptype` from them, then calculate **m**, **m1**, **m2** by order (**we will need hashmap which can keep iterate orders.**)