### PR TITLE
Change Filter definition to support dynamic filter.

### DIFF
--- a/src/adapter/file_adapter.rs
+++ b/src/adapter/file_adapter.rs
@@ -36,7 +36,7 @@ pub struct FileAdapter<P> {
 }
 
 type LoadPolicyFileHandler = fn(String, &mut dyn Model);
-type LoadFilteredPolicyFileHandler = fn(String, &mut dyn Model, f: &Filter) -> bool;
+type LoadFilteredPolicyFileHandler<'a> = fn(String, &mut dyn Model, f: &Filter<'a>) -> bool;
 
 impl<P> FileAdapter<P>
 where
@@ -64,11 +64,11 @@ where
         Ok(())
     }
 
-    async fn load_filtered_policy_file(
+    async fn load_filtered_policy_file<'a>(
         &self,
         m: &mut dyn Model,
-        filter: Filter,
-        handler: LoadFilteredPolicyFileHandler,
+        filter: Filter<'a>,
+        handler: LoadFilteredPolicyFileHandler<'a>,
     ) -> Result<bool> {
         let f = File::open(&self.file_path).await?;
         let mut lines = BufReader::new(f).lines();
@@ -100,7 +100,7 @@ where
         Ok(())
     }
 
-    async fn load_filtered_policy(&mut self, m: &mut dyn Model, f: Filter) -> Result<()> {
+    async fn load_filtered_policy<'a>(&mut self, m: &mut dyn Model, f: Filter<'a>) -> Result<()> {
         self.is_filtered = self
             .load_filtered_policy_file(m, f, load_filtered_policy_line)
             .await?;
@@ -208,7 +208,7 @@ fn load_policy_line(line: String, m: &mut dyn Model) {
     }
 }
 
-fn load_filtered_policy_line(line: String, m: &mut dyn Model, f: &Filter) -> bool {
+fn load_filtered_policy_line<'a>(line: String, m: &mut dyn Model, f: &Filter<'a>) -> bool {
     if line.is_empty() || line.starts_with('#') {
         return false;
     }

--- a/src/adapter/memory_adapter.rs
+++ b/src/adapter/memory_adapter.rs
@@ -31,7 +31,7 @@ impl Adapter for MemoryAdapter {
         Ok(())
     }
 
-    async fn load_filtered_policy(&mut self, m: &mut dyn Model, f: Filter) -> Result<()> {
+    async fn load_filtered_policy<'a>(&mut self, m: &mut dyn Model, f: Filter<'a>) -> Result<()> {
         for line in self.policy.iter() {
             let sec = &line[0];
             let ptype = &line[1];

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -13,15 +13,15 @@ pub use null_adapter::NullAdapter;
 use crate::{model::Model, Result};
 
 #[derive(Clone)]
-pub struct Filter {
-    pub p: Vec<&'static str>,
-    pub g: Vec<&'static str>,
+pub struct Filter<'a> {
+    pub p: Vec<&'a str>,
+    pub g: Vec<&'a str>,
 }
 
 #[async_trait]
 pub trait Adapter: Send + Sync {
     async fn load_policy(&self, m: &mut dyn Model) -> Result<()>;
-    async fn load_filtered_policy(&mut self, m: &mut dyn Model, f: Filter) -> Result<()>;
+    async fn load_filtered_policy<'a>(&mut self, m: &mut dyn Model, f: Filter<'a>) -> Result<()>;
     async fn save_policy(&mut self, m: &mut dyn Model) -> Result<()>;
     fn is_filtered(&self) -> bool;
     async fn add_policy(&mut self, sec: &str, ptype: &str, rule: Vec<String>) -> Result<bool>;

--- a/src/adapter/null_adapter.rs
+++ b/src/adapter/null_adapter.rs
@@ -14,7 +14,7 @@ impl Adapter for NullAdapter {
         Ok(())
     }
 
-    async fn load_filtered_policy(&mut self, _m: &mut dyn Model, _f: Filter) -> Result<()> {
+    async fn load_filtered_policy<'a>(&mut self, _m: &mut dyn Model, _f: Filter<'a>) -> Result<()> {
         Ok(())
     }
 

--- a/src/cached_enforcer.rs
+++ b/src/cached_enforcer.rs
@@ -223,7 +223,7 @@ impl CoreApi for CachedEnforcer {
     }
 
     #[inline]
-    async fn load_filtered_policy(&mut self, f: Filter) -> Result<()> {
+    async fn load_filtered_policy<'a>(&mut self, f: Filter<'a>) -> Result<()> {
         self.enforcer.load_filtered_policy(f).await
     }
 

--- a/src/core_api.rs
+++ b/src/core_api.rs
@@ -45,7 +45,7 @@ pub trait CoreApi: Send + Sync {
     #[cfg(feature = "incremental")]
     fn build_incremental_role_links(&mut self, d: EventData) -> Result<()>;
     async fn load_policy(&mut self) -> Result<()>;
-    async fn load_filtered_policy(&mut self, f: Filter) -> Result<()>;
+    async fn load_filtered_policy<'a>(&mut self, f: Filter<'a>) -> Result<()>;
     fn is_filtered(&self) -> bool;
     async fn save_policy(&mut self) -> Result<()>;
     fn clear_policy(&mut self);

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -429,7 +429,7 @@ impl CoreApi for Enforcer {
         Ok(())
     }
 
-    async fn load_filtered_policy(&mut self, f: Filter) -> Result<()> {
+    async fn load_filtered_policy<'a>(&mut self, f: Filter<'a>) -> Result<()> {
         self.model.clear_policy();
         self.adapter
             .load_filtered_policy(&mut *self.model, f)


### PR DESCRIPTION
Values of type `&'static str` must be known at compile time. Using a
lifetime of `&'a str` allows use of filter values determined at runtime.

Fixes https://github.com/casbin/casbin-rs/issues/195