### PR TITLE
feat: switch to lru

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,5 +28,5 @@ jobs:
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: Update Changelog
+        commit_message: 'changelog: auto update by ci'
         file_pattern: CHANGELOG.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["auth", "authorization", "rbac", "acl", "abac"]
 regex = "1.4.0"
 rhai = { version = "0.19.7", features = ["sync", "only_i32", "no_function", "no_float", "no_optimize", "no_module", "serde", "unchecked"] }
 ip_network = { version = "0.3.4", optional = true }
-lru-cache = { version = "0.1.2", optional = true }
+lru = { version = "0.6.2", optional = true }
 lazy_static = "1.4.0"
 indexmap = "1.6.0"
 async-std = { version = "1.8.0", optional = true }
@@ -37,7 +37,7 @@ runtime-async-std = ["async-std"]
 logging = ["slog", "slog-term", "slog-async"]
 ip = ["ip_network"]
 glob = ["globset"]
-cached = ["lru-cache"]
+cached = ["lru"]
 watcher = []
 incremental = []
 explain = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ip_network = { version = "0.3.4", optional = true }
 lru-cache = { version = "0.1.2", optional = true }
 lazy_static = "1.4.0"
 indexmap = "1.6.0"
-async-std = { version = "1.7.0", optional = true }
+async-std = { version = "1.8.0", optional = true }
 async-trait = "0.1.37"
 tokio = { version = "0.3.5", optional = true, default-features = false }
 globset = { version = "0.4.5", optional = true }
@@ -51,5 +51,5 @@ serde = { version = "1.0.115", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "0.3.5", features = [ "full" ] }
-async-std = { version = "1.7.0", features = [ "attributes" ] }
+async-std = { version = "1.8.0", features = [ "attributes" ] }
 serde = { version = "1.0.115", features = ["derive"] }

--- a/src/cache/default_cache.rs
+++ b/src/cache/default_cache.rs
@@ -1,6 +1,6 @@
 use crate::cache::Cache;
 
-use lru_cache::LruCache;
+use lru::LruCache;
 
 use std::{borrow::Cow, hash::Hash};
 
@@ -30,7 +30,7 @@ where
     V: Send + Sync + Clone + 'static,
 {
     fn set_capacity(&mut self, cap: usize) {
-        self.cache.set_capacity(cap);
+        self.cache.resize(cap);
     }
 
     fn get(&mut self, k: &K) -> Option<Cow<'_, V>> {
@@ -38,14 +38,14 @@ where
     }
 
     fn has(&mut self, k: &K) -> bool {
-        self.cache.contains_key(k)
+        self.cache.contains(k)
     }
 
     fn set(&mut self, k: K, v: V) {
         if self.has(&k) {
-            self.cache.remove(&k);
+            self.cache.pop(&k);
         }
-        self.cache.insert(k, v);
+        self.cache.put(k, v);
     }
 
     fn clear(&mut self) {


### PR DESCRIPTION
- async-std 1.7 -> 1.8
- lru-cache -> lru 

The switch to lru is only because it is still actively maintained.
Also, the overlap of partial dependencies may reduce compilation costs and size, albeit to a small degree.