### PR TITLE
bump rhai to 0.19.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ip_network  = { version = "0.3.4", optional = true }
 lazy_static = "1.4.0"
 lru         = { version = "0.6.3", optional = true }
 regex       = "1.4.3"
-rhai        = { version = "0.19.10", features = [
+rhai        = { version = "0.19.15", features = [
     "sync",
     "only_i32",
     "no_function",

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -31,7 +31,7 @@ use rhai::{
         ArithmeticPackage, BasicArrayPackage, BasicMapPackage, LogicPackage,
         Package,
     },
-    Dynamic, Engine, EvalAltResult, ImmutableString, RegisterFn, Scope,
+    Dynamic, Engine, EvalAltResult, ImmutableString, Scope,
 };
 
 def_package!(rhai:CasbinPackage:"Package for Casbin", lib, {
@@ -40,7 +40,7 @@ def_package!(rhai:CasbinPackage:"Package for Casbin", lib, {
     BasicArrayPackage::init(lib);
     BasicMapPackage::init(lib);
 
-    lib.set_fn_1("escape_assertion", |s: ImmutableString| {
+    lib.set_native_fn("escape_assertion", |s: ImmutableString| {
         Ok(escape_assertion(&s))
     });
 });


### PR DESCRIPTION
On running ```cargo build```, build was failing - 
```
warning: unused import: `RegisterFn`
  --> src/enforcer.rs:34:54
   |
34 |     Dynamic, Engine, EvalAltResult, ImmutableString, RegisterFn, Scope,
   |                                                      ^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: use of deprecated trait `rhai::RegisterFn`: this trait is no longer needed and will be removed in the future
  --> src/enforcer.rs:34:54
   |
34 |     Dynamic, Engine, EvalAltResult, ImmutableString, RegisterFn, Scope,
   |                                                      ^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

error[E0599]: no method named `set_fn_1` found for mutable reference `&mut Module` in the current scope
  --> src/enforcer.rs:43:9
   |
43 |     lib.set_fn_1("escape_assertion", |s: ImmutableString| {
   |         ^^^^^^^^ help: there is an associated function with a similar name: `set_fn`
```

This PR fixes this issue.
Signed-off-by: smrpn <samarpan_d@pp.iitr.ac.in>