### PR TITLE
feat: add comment for benchmark result

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,8 @@ jobs:
             ~/.cargo/git
             ~/.cargo/registry
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: boa-dev/criterion-compare-action@move_to_actions
+      - uses: smrpn/criterion-compare-action@move_to_actions 
         with:
           cwd: benches
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
There is a issue with criterion-benchmark-action. This does not allow comments from PRs from forked repositories. 
ref - https://github.community/t5/GitHub-Actions/quot-Resource-not-accessible-by-integration-quot-for-adding-a/td-p/33925
This will allow comments from PRs inside the repository only.


Signed-off-by: smrpn <samarpan_d@pp.iitr.ac.in>