### PR TITLE
perf: use parking_lot::RwLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ indexmap    = "1.6.2"
 ip_network  = { version = "0.3.4", optional = true }
 lazy_static = "1.4.0"
 lru         = { version = "0.6.5", optional = true }
+parking_lot = "0.11"
 regex       = "1.4.5"
 rhai        = { version = "0.20.0", features = [
     "sync",

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -142,11 +142,7 @@ fn b_benchmark_role_manager_small(c: &mut Criterion) {
     c.bench_function("benchmark_role_manager_small", |b| {
         b.iter(|| {
             (0..100_u64).for_each(|i| {
-                rm.write().unwrap().has_link(
-                    "user501",
-                    &format!("group{}", i),
-                    None,
-                );
+                rm.write().has_link("user501", &format!("group{}", i), None);
             })
         })
     });
@@ -268,11 +264,8 @@ fn b_benchmark_role_manager_medium(c: &mut Criterion) {
     c.bench_function("benchmark_role_manager_medium", |b| {
         b.iter(|| {
             (0..1000_u64).for_each(|i| {
-                rm.write().unwrap().has_link(
-                    "user5001",
-                    &format!("group{}", i),
-                    None,
-                );
+                rm.write()
+                    .has_link("user5001", &format!("group{}", i), None);
             })
         })
     });
@@ -394,11 +387,8 @@ fn b_benchmark_role_manager_large(c: &mut Criterion) {
     c.bench_function("benchmark_role_manager_large", |b| {
         b.iter(|| {
             (0..10000_u64).for_each(|i| {
-                rm.write().unwrap().has_link(
-                    "user50001",
-                    &format!("group{}", i),
-                    None,
-                );
+                rm.write()
+                    .has_link("user50001", &format!("group{}", i), None);
             })
         })
     });

--- a/src/cached_enforcer.rs
+++ b/src/cached_enforcer.rs
@@ -25,12 +25,10 @@ use crate::logger::Logger;
 use crate::{error::ModelError, get_or_err};
 
 use async_trait::async_trait;
+use parking_lot::RwLock;
 use rhai::{Dynamic, ImmutableString};
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, sync::Arc};
 
 type EventCallback = fn(&mut CachedEnforcer, EventData);
 

--- a/src/core_api.rs
+++ b/src/core_api.rs
@@ -13,9 +13,10 @@ use crate::Logger;
 use crate::emitter::EventData;
 
 use async_trait::async_trait;
+use parking_lot::RwLock;
 use rhai::ImmutableString;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 #[async_trait]
 pub trait CoreApi: Send + Sync {

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -25,6 +25,7 @@ use crate::{DefaultLogger, Logger};
 
 use async_trait::async_trait;
 use lazy_static::lazy_static;
+use parking_lot::RwLock;
 use rhai::{
     def_package,
     packages::{
@@ -49,11 +50,7 @@ lazy_static! {
     static ref CASBIN_PACKAGE: CasbinPackage = CasbinPackage::new();
 }
 
-use std::{
-    cmp::max,
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::{cmp::max, collections::HashMap, sync::Arc};
 
 type EventCallback = fn(&mut Enforcer, EventData);
 
@@ -434,7 +431,7 @@ impl CoreApi for Enforcer {
     }
 
     fn build_role_links(&mut self) -> Result<()> {
-        self.rm.write().unwrap().clear();
+        self.rm.write().clear();
         self.model.build_role_links(Arc::clone(&self.rm))?;
 
         Ok(())

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,7 +31,7 @@ macro_rules! register_g_function {
             $enforcer.engine.register_fn(
                 $fname,
                 move |arg1: ImmutableString, arg2: ImmutableString| {
-                    rm.write().unwrap().has_link(&arg1, &arg2, None)
+                    rm.write().has_link(&arg1, &arg2, None)
                 },
             );
         } else if count == 3 {
@@ -40,7 +40,7 @@ macro_rules! register_g_function {
                 move |arg1: ImmutableString,
                       arg2: ImmutableString,
                       arg3: ImmutableString| {
-                    rm.write().unwrap().has_link(&arg1, &arg2, Some(&arg3))
+                    rm.write().has_link(&arg1, &arg2, Some(&arg3))
                 },
             );
         } else {

--- a/src/model/assertion.rs
+++ b/src/model/assertion.rs
@@ -8,8 +8,9 @@ use crate::{
 use crate::emitter::EventData;
 
 use indexmap::{IndexMap, IndexSet};
+use parking_lot::RwLock;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 pub type AssertionMap = IndexMap<String, Assertion>;
 
@@ -66,13 +67,9 @@ impl Assertion {
                 .into());
             }
             if count == 2 {
-                rm.write().unwrap().add_link(&rule[0], &rule[1], None);
+                rm.write().add_link(&rule[0], &rule[1], None);
             } else if count == 3 {
-                rm.write().unwrap().add_link(
-                    &rule[0],
-                    &rule[1],
-                    Some(&rule[2]),
-                );
+                rm.write().add_link(&rule[0], &rule[1], Some(&rule[2]));
             } else if count >= 4 {
                 return Err(ModelError::P(
                     "Multiple domains are not supported".to_owned(),
@@ -119,21 +116,15 @@ impl Assertion {
                 }
                 if count == 2 {
                     if insert {
-                        rm.write().unwrap().add_link(&rule[0], &rule[1], None);
+                        rm.write().add_link(&rule[0], &rule[1], None);
                     } else {
-                        rm.write()
-                            .unwrap()
-                            .delete_link(&rule[0], &rule[1], None)?;
+                        rm.write().delete_link(&rule[0], &rule[1], None)?;
                     }
                 } else if count == 3 {
                     if insert {
-                        rm.write().unwrap().add_link(
-                            &rule[0],
-                            &rule[1],
-                            Some(&rule[2]),
-                        );
+                        rm.write().add_link(&rule[0], &rule[1], Some(&rule[2]));
                     } else {
-                        rm.write().unwrap().delete_link(
+                        rm.write().delete_link(
                             &rule[0],
                             &rule[1],
                             Some(&rule[2]),

--- a/src/model/default_model.rs
+++ b/src/model/default_model.rs
@@ -11,6 +11,7 @@ use crate::{
 use crate::emitter::EventData;
 
 use indexmap::{IndexMap, IndexSet};
+use parking_lot::RwLock;
 
 #[cfg(all(feature = "runtime-async-std", not(target_arch = "wasm32")))]
 use async_std::path::Path;
@@ -18,10 +19,7 @@ use async_std::path::Path;
 #[cfg(feature = "runtime-tokio")]
 use std::path::Path;
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, sync::Arc};
 
 #[derive(Clone, Default)]
 pub struct DefaultModel {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,10 +3,9 @@ use crate::{rbac::RoleManager, Result};
 #[cfg(feature = "incremental")]
 use crate::emitter::EventData;
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use parking_lot::RwLock;
+
+use std::{collections::HashMap, sync::Arc};
 
 mod assertion;
 mod default_model;

--- a/src/rbac_api.rs
+++ b/src/rbac_api.rs
@@ -219,7 +219,7 @@ where
         let mut roles = vec![];
         if let Some(t1) = self.get_mut_model().get_mut_model().get_mut("g") {
             if let Some(t2) = t1.get_mut("g") {
-                roles = t2.rm.write().unwrap().get_roles(name, domain);
+                roles = t2.rm.write().get_roles(name, domain);
             }
         }
 
@@ -233,7 +233,7 @@ where
     ) -> Vec<String> {
         if let Some(t1) = self.get_model().get_model().get("g") {
             if let Some(t2) = t1.get("g") {
-                return t2.rm.read().unwrap().get_users(name, domain);
+                return t2.rm.read().get_users(name, domain);
             }
         }
         return vec![];
@@ -317,11 +317,8 @@ where
         let mut q: Vec<String> = vec![name.to_owned()];
         while !q.is_empty() {
             let name = q.swap_remove(0);
-            let roles = self
-                .get_role_manager()
-                .write()
-                .unwrap()
-                .get_roles(&name, domain);
+            let roles =
+                self.get_role_manager().write().get_roles(&name, domain);
             for r in roles.into_iter() {
                 if res.insert(r.to_owned()) {
                     q.push(r);
@@ -359,10 +356,7 @@ where
             roles
                 .iter()
                 .map(|role| {
-                    self.get_role_manager()
-                        .read()
-                        .unwrap()
-                        .get_users(role, None)
+                    self.get_role_manager().read().get_users(role, None)
                 })
                 .flatten(),
         );
@@ -521,7 +515,9 @@ mod tests {
         tokio::test
     )]
     async fn test_role_api_threads() {
-        use std::sync::{Arc, RwLock};
+        use parking_lot::RwLock;
+
+        use std::sync::Arc;
         use std::thread;
 
         #[cfg(feature = "runtime-async-std")]

--- a/src/rbac_api.rs
+++ b/src/rbac_api.rs
@@ -533,32 +533,28 @@ mod tests {
 
         assert_eq!(
             vec!["data2_admin"],
-            e.write().unwrap().get_roles_for_user("alice", None)
+            e.write().get_roles_for_user("alice", None)
         );
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("bob", None)
+            e.write().get_roles_for_user("bob", None)
         );
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("data2_admin", None)
+            e.write().get_roles_for_user("data2_admin", None)
         );
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("non_exists", None)
+            e.write().get_roles_for_user("non_exists", None)
         );
 
         assert_eq!(
             false,
-            e.write()
-                .unwrap()
-                .has_role_for_user("alice", "data1_admin", None)
+            e.write().has_role_for_user("alice", "data1_admin", None)
         );
         assert_eq!(
             true,
-            e.write()
-                .unwrap()
-                .has_role_for_user("alice", "data2_admin", None)
+            e.write().has_role_for_user("alice", "data2_admin", None)
         );
 
         thread::spawn(move || {
@@ -566,7 +562,6 @@ mod tests {
             {
                 task::block_on(async move {
                     ee.write()
-                        .unwrap()
                         .add_role_for_user("alice", "data1_admin", None)
                         .await
                         .unwrap();
@@ -574,24 +569,19 @@ mod tests {
                     assert_eq!(
                         vec!["data1_admin", "data2_admin"],
                         sort_unstable(
-                            ee.write()
-                                .unwrap()
-                                .get_roles_for_user("alice", None)
+                            ee.write().get_roles_for_user("alice", None)
                         )
                     );
                     assert_eq!(
                         vec![String::new(); 0],
-                        ee.write().unwrap().get_roles_for_user("bob", None)
+                        ee.write().get_roles_for_user("bob", None)
                     );
                     assert_eq!(
                         vec![String::new(); 0],
-                        ee.write()
-                            .unwrap()
-                            .get_roles_for_user("data2_admin", None)
+                        ee.write().get_roles_for_user("data2_admin", None)
                     );
 
                     ee.write()
-                        .unwrap()
                         .add_roles_for_user(
                             "bob",
                             vec!["data2_admin"]
@@ -606,20 +596,16 @@ mod tests {
                     assert_eq!(
                         vec!["data1_admin", "data2_admin"],
                         sort_unstable(
-                            ee.write()
-                                .unwrap()
-                                .get_roles_for_user("alice", None)
+                            ee.write().get_roles_for_user("alice", None)
                         )
                     );
                     assert_eq!(
                         vec!["data2_admin"],
-                        ee.write().unwrap().get_roles_for_user("bob", None)
+                        ee.write().get_roles_for_user("bob", None)
                     );
                     assert_eq!(
                         vec![String::new(); 0],
-                        ee.write()
-                            .unwrap()
-                            .get_roles_for_user("data2_admin", None)
+                        ee.write().get_roles_for_user("data2_admin", None)
                     );
                 });
             }
@@ -632,30 +618,24 @@ mod tests {
                     .unwrap()
                     .block_on(async move {
                         ee.write()
-                            .unwrap()
                             .add_role_for_user("alice", "data1_admin", None)
                             .await
                             .unwrap();
 
                         assert_eq!(
                             vec!["data2_admin", "data1_admin"],
-                            ee.write()
-                                .unwrap()
-                                .get_roles_for_user("alice", None)
+                            ee.write().get_roles_for_user("alice", None)
                         );
                         assert_eq!(
                             vec![String::new(); 0],
-                            ee.write().unwrap().get_roles_for_user("bob", None)
+                            ee.write().get_roles_for_user("bob", None)
                         );
                         assert_eq!(
                             vec![String::new(); 0],
-                            ee.write()
-                                .unwrap()
-                                .get_roles_for_user("data2_admin", None)
+                            ee.write().get_roles_for_user("data2_admin", None)
                         );
 
                         ee.write()
-                            .unwrap()
                             .add_roles_for_user(
                                 "bob",
                                 vec!["data2_admin".to_owned()],
@@ -666,19 +646,15 @@ mod tests {
 
                         assert_eq!(
                             vec!["data2_admin", "data1_admin"],
-                            ee.write()
-                                .unwrap()
-                                .get_roles_for_user("alice", None)
+                            ee.write().get_roles_for_user("alice", None)
                         );
                         assert_eq!(
                             vec!["data2_admin"],
-                            ee.write().unwrap().get_roles_for_user("bob", None)
+                            ee.write().get_roles_for_user("bob", None)
                         );
                         assert_eq!(
                             vec![String::new(); 0],
-                            ee.write()
-                                .unwrap()
-                                .get_roles_for_user("data2_admin", None)
+                            ee.write().get_roles_for_user("data2_admin", None)
                         );
                     });
             }
@@ -687,184 +663,110 @@ mod tests {
         .unwrap();
 
         e.write()
-            .unwrap()
             .delete_role_for_user("alice", "data1_admin", None)
             .await
             .unwrap();
-        e.write()
-            .unwrap()
-            .delete_roles_for_user("bob", None)
-            .await
-            .unwrap();
+        e.write().delete_roles_for_user("bob", None).await.unwrap();
         assert_eq!(
             vec!["data2_admin"],
-            e.write().unwrap().get_roles_for_user("alice", None)
+            e.write().get_roles_for_user("alice", None)
         );
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("bob", None)
+            e.write().get_roles_for_user("bob", None)
         );
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("data2_admin", None)
+            e.write().get_roles_for_user("data2_admin", None)
         );
 
         e.write()
-            .unwrap()
             .delete_roles_for_user("alice", None)
             .await
             .unwrap();
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("alice", None)
+            e.write().get_roles_for_user("alice", None)
         );
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("bob", None)
+            e.write().get_roles_for_user("bob", None)
         );
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("data2_admin", None)
+            e.write().get_roles_for_user("data2_admin", None)
         );
 
         e.write()
-            .unwrap()
             .add_role_for_user("alice", "data1_admin", None)
             .await
             .unwrap();
-        e.write().unwrap().delete_user("alice").await.unwrap();
+        e.write().delete_user("alice").await.unwrap();
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("alice", None)
+            e.write().get_roles_for_user("alice", None)
         );
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("bob", None)
+            e.write().get_roles_for_user("bob", None)
         );
         assert_eq!(
             vec![String::new(); 0],
-            e.write().unwrap().get_roles_for_user("data2_admin", None)
+            e.write().get_roles_for_user("data2_admin", None)
         );
 
         e.write()
-            .unwrap()
             .add_role_for_user("alice", "data2_admin", None)
             .await
             .unwrap();
         assert_eq!(
             true,
-            e.write()
-                .unwrap()
-                .enforce(("alice", "data1", "read"))
-                .unwrap()
+            e.write().enforce(("alice", "data1", "read")).unwrap()
         );
         assert_eq!(
             false,
-            e.write()
-                .unwrap()
-                .enforce(("alice", "data1", "write"))
-                .unwrap()
+            e.write().enforce(("alice", "data1", "write")).unwrap()
         );
         assert_eq!(
             true,
-            e.write()
-                .unwrap()
-                .enforce(("alice", "data2", "read"))
-                .unwrap()
+            e.write().enforce(("alice", "data2", "read")).unwrap()
         );
         assert_eq!(
             true,
-            e.write()
-                .unwrap()
-                .enforce(("alice", "data2", "write"))
-                .unwrap()
+            e.write().enforce(("alice", "data2", "write")).unwrap()
         );
+        assert_eq!(false, e.write().enforce(("bob", "data1", "read")).unwrap());
         assert_eq!(
             false,
-            e.write()
-                .unwrap()
-                .enforce(("bob", "data1", "read"))
-                .unwrap()
+            e.write().enforce(("bob", "data1", "write")).unwrap()
         );
-        assert_eq!(
-            false,
-            e.write()
-                .unwrap()
-                .enforce(("bob", "data1", "write"))
-                .unwrap()
-        );
-        assert_eq!(
-            false,
-            e.write()
-                .unwrap()
-                .enforce(("bob", "data2", "read"))
-                .unwrap()
-        );
-        assert_eq!(
-            true,
-            e.write()
-                .unwrap()
-                .enforce(("bob", "data2", "write"))
-                .unwrap()
-        );
+        assert_eq!(false, e.write().enforce(("bob", "data2", "read")).unwrap());
+        assert_eq!(true, e.write().enforce(("bob", "data2", "write")).unwrap());
 
-        e.write().unwrap().delete_role("data2_admin").await.unwrap();
+        e.write().delete_role("data2_admin").await.unwrap();
         assert_eq!(
             true,
-            e.write()
-                .unwrap()
-                .enforce(("alice", "data1", "read"))
-                .unwrap()
+            e.write().enforce(("alice", "data1", "read")).unwrap()
         );
         assert_eq!(
             false,
-            e.write()
-                .unwrap()
-                .enforce(("alice", "data1", "write"))
-                .unwrap()
+            e.write().enforce(("alice", "data1", "write")).unwrap()
         );
         assert_eq!(
             false,
-            e.write()
-                .unwrap()
-                .enforce(("alice", "data2", "read"))
-                .unwrap()
+            e.write().enforce(("alice", "data2", "read")).unwrap()
         );
         assert_eq!(
             false,
-            e.write()
-                .unwrap()
-                .enforce(("alice", "data2", "write"))
-                .unwrap()
+            e.write().enforce(("alice", "data2", "write")).unwrap()
         );
+        assert_eq!(false, e.write().enforce(("bob", "data1", "read")).unwrap());
         assert_eq!(
             false,
-            e.write()
-                .unwrap()
-                .enforce(("bob", "data1", "read"))
-                .unwrap()
+            e.write().enforce(("bob", "data1", "write")).unwrap()
         );
-        assert_eq!(
-            false,
-            e.write()
-                .unwrap()
-                .enforce(("bob", "data1", "write"))
-                .unwrap()
-        );
-        assert_eq!(
-            false,
-            e.write()
-                .unwrap()
-                .enforce(("bob", "data2", "read"))
-                .unwrap()
-        );
-        assert_eq!(
-            true,
-            e.write()
-                .unwrap()
-                .enforce(("bob", "data2", "write"))
-                .unwrap()
-        );
+        assert_eq!(false, e.write().enforce(("bob", "data2", "read")).unwrap());
+        assert_eq!(true, e.write().enforce(("bob", "data2", "write")).unwrap());
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -1184,7 +1086,6 @@ mod tests {
 
         e.get_role_manager()
             .write()
-            .unwrap()
             .matching_fn(Some(key_match2), None);
 
         assert!(e.enforce(("alice", "/pen/1", "GET")).unwrap());
@@ -1230,7 +1131,6 @@ mod tests {
 
         e.get_role_manager()
             .write()
-            .unwrap()
             .matching_fn(None, Some(key_match));
 
         assert!(e.enforce(("alice", "domain1", "data1", "read")).unwrap());
@@ -1275,7 +1175,6 @@ mod tests {
 
         e.get_role_manager()
             .write()
-            .unwrap()
             .matching_fn(Some(key_match), None);
 
         assert!(e.enforce(("alice", "/pen/1", "GET")).unwrap());


### PR DESCRIPTION
`parking_lot::RwLock` performs better than `std::sync::RwLock` in most benchmarks.

Since `parking_lot` has been indirectly dependent, there is no need to sacrifice compilation time.