### PR TITLE
feat: switch to ritelinked and provide amortized feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,19 +76,19 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features runtime-async-std,cached,glob,ip,watcher,logging,incremental,explain
+          args: --no-default-features --features runtime-async-std,amortized,cached,glob,ip,watcher,logging,incremental,explain
 
       - name: Cargo Test For All Features Using tokio
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features runtime-tokio,cached,glob,ip,watcher,logging,incremental,explain
+          args: --no-default-features --features runtime-tokio,amortized,cached,glob,ip,watcher,logging,incremental,explain
 
       - name: Cargo Check Wasm
         uses: actions-rs/cargo@v1
         with:
           command:  check
-          args: --target wasm32-unknown-unknown --no-default-features --features runtime-async-std,cached,glob,ip,watcher,logging,incremental
+          args: --target wasm32-unknown-unknown --no-default-features --features runtime-async-std,amortized,cached,glob,ip,watcher,logging,incremental
 
       - name: Clippy warnings
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version     = "2.0.7"
 async-std   = { version = "1.9.0", optional = true }
 async-trait = "0.1.48"
 globset     = { version = "0.4.6", optional = true }
-indexmap    = "1.6.2"
+ritelinked  = { version = "0.3.0", default-features = false, features = ["ahash", "inline-more"] }
 ip_network  = { version = "0.3.4", optional = true }
 lazy_static = "1.4.0"
 lru         = { version = "0.6.5", optional = true }
@@ -43,6 +43,7 @@ tokio-stream = { version = "0.1", optional = true, default-features = false }
 [features]
 default = ["runtime-tokio", "incremental"]
 
+amortized         = ["ritelinked/ahash-amortized", "ritelinked/inline-more-amortized"]
 cached            = ["lru"]
 explain           = []
 glob              = ["globset"]

--- a/src/adapter/memory_adapter.rs
+++ b/src/adapter/memory_adapter.rs
@@ -5,11 +5,11 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use indexmap::IndexSet;
+use ritelinked::LinkedHashSet;
 
 #[derive(Default)]
 pub struct MemoryAdapter {
-    policy: IndexSet<Vec<String>>,
+    policy: LinkedHashSet<Vec<String>>,
     is_filtered: bool,
 }
 
@@ -199,7 +199,7 @@ impl Adapter for MemoryAdapter {
             return Ok(false);
         }
 
-        let mut tmp = IndexSet::new();
+        let mut tmp = LinkedHashSet::new();
         let mut res = false;
         for rule in &self.policy {
             if sec == rule[0] && ptype == rule[1] {

--- a/src/cached_enforcer.rs
+++ b/src/cached_enforcer.rs
@@ -215,7 +215,7 @@ impl CoreApi for CachedEnforcer {
                 let rules: Vec<String> = indices
                     .into_iter()
                     .filter_map(|y| {
-                        all_rules.get_index(y).map(|x| x.join(", "))
+                        all_rules.iter().nth(y).map(|x| x.join(", "))
                     })
                     .collect();
 

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -415,7 +415,7 @@ impl CoreApi for Enforcer {
                 let rules: Vec<String> = indices
                     .into_iter()
                     .filter_map(|y| {
-                        all_rules.get_index(y).map(|x| x.join(", "))
+                        all_rules.iter().nth(y).map(|x| x.join(", "))
                     })
                     .collect();
 

--- a/src/model/assertion.rs
+++ b/src/model/assertion.rs
@@ -7,19 +7,19 @@ use crate::{
 #[cfg(feature = "incremental")]
 use crate::emitter::EventData;
 
-use indexmap::{IndexMap, IndexSet};
 use parking_lot::RwLock;
+use ritelinked::{LinkedHashMap, LinkedHashSet};
 
 use std::sync::Arc;
 
-pub type AssertionMap = IndexMap<String, Assertion>;
+pub type AssertionMap = LinkedHashMap<String, Assertion>;
 
 #[derive(Clone)]
 pub struct Assertion {
     pub(crate) key: String,
     pub(crate) value: String,
     pub(crate) tokens: Vec<String>,
-    pub(crate) policy: IndexSet<Vec<String>>,
+    pub(crate) policy: LinkedHashSet<Vec<String>>,
     pub(crate) rm: Arc<RwLock<dyn RoleManager>>,
 }
 
@@ -29,7 +29,7 @@ impl Default for Assertion {
             key: String::new(),
             value: String::new(),
             tokens: vec![],
-            policy: IndexSet::new(),
+            policy: LinkedHashSet::new(),
             rm: Arc::new(RwLock::new(DefaultRoleManager::new(0))),
         }
     }
@@ -37,12 +37,12 @@ impl Default for Assertion {
 
 impl Assertion {
     #[inline]
-    pub fn get_policy(&self) -> &IndexSet<Vec<String>> {
+    pub fn get_policy(&self) -> &LinkedHashSet<Vec<String>> {
         &self.policy
     }
 
     #[inline]
-    pub fn get_mut_policy(&mut self) -> &mut IndexSet<Vec<String>> {
+    pub fn get_mut_policy(&mut self) -> &mut LinkedHashSet<Vec<String>> {
         &mut self.policy
     }
 

--- a/src/model/default_model.rs
+++ b/src/model/default_model.rs
@@ -10,8 +10,8 @@ use crate::{
 #[cfg(feature = "incremental")]
 use crate::emitter::EventData;
 
-use indexmap::{IndexMap, IndexSet};
 use parking_lot::RwLock;
+use ritelinked::{LinkedHashMap, LinkedHashSet};
 
 #[cfg(all(feature = "runtime-async-std", not(target_arch = "wasm32")))]
 use async_std::path::Path;
@@ -137,7 +137,7 @@ impl Model for DefaultModel {
         if let Some(new_model) = self.model.get_mut(sec) {
             new_model.insert(key.to_owned(), ast);
         } else {
-            let mut new_ast_map = IndexMap::new();
+            let mut new_ast_map = LinkedHashMap::new();
             new_ast_map.insert(key.to_owned(), ast);
             self.model.insert(sec.to_owned(), new_ast_map);
         }
@@ -286,7 +286,7 @@ impl Model for DefaultModel {
     ) -> Vec<String> {
         self.get_policy(sec, ptype)
             .into_iter()
-            .fold(IndexSet::new(), |mut acc, x| {
+            .fold(LinkedHashSet::new(), |mut acc, x| {
                 acc.insert(x[field_index].clone());
                 acc
             })


### PR DESCRIPTION
In this PR, I use my crate `ritelinked` to replace `indexmap`. In the local test, it will bring a big performance improvement for most benchmarks. Of course, this still needs to be further evaluated.

In addition, a new `amortized` feature is provided. Thanks to `griddle` , although it will slow down the performance, but there is reason to believe that it can reduce the long tail effect.

Signed-off-by: Chojan Shang <psiace@outlook.com>