### PR TITLE
Initial migration from rust 2018 to rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors     = ["Joey <joey.xf@gmail.com>", "Cheng JIANG <jiang.cheng@vip.163.com>"]
 description = "An authorization library that supports access control models like ACL, RBAC, ABAC."
-edition     = "2018"
+edition     = "2021"
 homepage    = "https://casbin.org/"
 keywords    = ["auth", "authorization", "rbac", "acl", "abac"]
 license     = "Apache-2.0"
@@ -23,7 +23,7 @@ lazy_static = "1.4.0"
 lru         = { version = "0.7.0", optional = true }
 parking_lot = "0.11"
 regex       = "1.5.4"
-rhai        = { version = "1.4.0", features = [
+rhai        = { version = "1.5.0", features = [
     "sync",
     "only_i32",
     "no_function",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,7 @@ name        = "casbin"
 readme      = "README.md"
 repository  = "https://github.com/casbin/casbin-rs"
 version     = "2.0.9"
-edition = "2018"
-homepage = "https://casbin.org/"
-keywords = ["auth", "authorization", "rbac", "acl", "abac"]
-license = "Apache-2.0"
-name = "casbin"
-readme = "README.md"
-repository = "https://github.com/casbin/casbin-rs"
-version = "2.0.9"
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,18 @@ version     = "2.0.9"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { version = "1.9.0", optional = true }
+async-std = { version = "1.10.0", optional = true }
 
-async-trait = "0.1.51"
+async-trait = "0.1.52"
 globset = { version = "0.4.8", optional = true }
-ritelinked = { version = "0.3.1", default-features = false, features = [
+ritelinked = { version = "0.3.2", default-features = false, features = [
   "ahash",
   "inline-more",
 ] }
-ip_network = { version = "0.4.0", optional = true }
+ip_network = { version = "0.4.1", optional = true }
 once_cell = "1.9.0"
-lru = { version = "0.7.0", optional = true }
-parking_lot = "0.11"
+lru = { version = "0.7.3", optional = true }
+parking_lot = "0.12.0"
 regex = "1.5.4"
 rhai = { version = "1.5.0", features = [
   "sync",
@@ -37,13 +37,13 @@ rhai = { version = "1.5.0", features = [
   "serde",
   "unchecked",
 ] }
-serde = "1.0.127"
+serde = "1.0.136"
 slog = { version = "2.7.0", optional = true }
-slog-async = { version = "2.6.0", optional = true }
-slog-term = { version = "2.8.0", optional = true }
-thiserror = "1.0.26"
-tokio = { version = "1.10.0", optional = true, default-features = false }
-tokio-stream = { version = "0.1", optional = true, default-features = false }
+slog-async = { version = "2.7.0", optional = true }
+slog-term = { version = "2.9.0", optional = true }
+thiserror = "1.0.30"
+tokio = { version = "1.17.0", optional = true, default-features = false }
+tokio-stream = { version = "0.1.8", optional = true, default-features = false }
 
 [features]
 default = ["runtime-tokio", "incremental"]
@@ -60,13 +60,13 @@ runtime-tokio = ["tokio/fs", "tokio/io-util"]
 watcher = []
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-async-std = { version = "1.9.0", features = ["attributes"] }
-serde = { version = "1.0.127", features = ["derive"] }
+async-std = { version = "1.10.0", features = ["attributes"] }
+serde = { version = "1.0.136", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-async-std = { version = "1.9.0", features = ["attributes"] }
-serde = { version = "1.0.127", features = ["derive"] }
-tokio = { version = "1.10.0", features = ["full"] }
+async-std = { version = "1.10.0", features = ["attributes"] }
+serde = { version = "1.0.136", features = ["derive"] }
+tokio = { version = "1.17.0", features = ["full"] }
 
 [profile.release]
 codegen-units = 1
@@ -85,7 +85,7 @@ name = "benchmark"
 harness = false
 
 [dev-dependencies]
-criterion = { version = "0.3", features = ["html_reports"] }
+criterion = { version = "0.3.5", features = ["html_reports"] }
 
 [lib]
 bench = false


### PR DESCRIPTION
Steps followed to migrate from rust 2018 to 2021:

1. `cargo update`
2. `cargo fix –-edition`
3. updated the `cargo.toml` --edition
4. ran `cargo build` and `cargo test` to check whether changes are implemented and code is running. The warnings were resolved after the update in main repository which included the change of syntax of `def_package!` compatible with latest `rhai` edition
5. Updated the `Cargo.toml` file dependencies to their latest version
6. `cargo +nightly udeps` to check the unused dependencies, found none
7. `cargo outdated` to check outdated dependencies, found some, updated via `cargo update`
8. `cargo build` and `cargo test` to verify the changes are implemented successfully

Following is the output when ran `cargo outdated`
![Screen Shot 2022-03-03 at 7 44 40 PM](https://user-images.githubusercontent.com/85673539/156582414-ebe2e66d-90a0-4b14-9505-aaac8335731c.png)

Following is the output when ran `cargo +nightly udeps`
![Screen Shot 2022-03-03 at 7 46 01 PM](https://user-images.githubusercontent.com/85673539/156582513-acb2faa6-bc14-4adf-a912-93d42e3960d0.png)

