### PR TITLE
Use petgraph inside DefaultRoleManager to model relations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ once_cell = "1.9.0"
 lru = { version = "0.7.3", optional = true }
 parking_lot = "0.12.0"
 regex = "1.5.4"
+petgraph = "0.6"
+fixedbitset = "0.4"
 rhai = { version = "1.5.0", features = [
   "sync",
   "only_i32",

--- a/src/adapter/file_adapter.rs
+++ b/src/adapter/file_adapter.rs
@@ -1,6 +1,6 @@
 use crate::{
     adapter::{Adapter, Filter},
-    error::ModelError,
+    error::{AdapterError, ModelError},
     model::Model,
     util::parse_csv_line,
     Result,
@@ -29,6 +29,7 @@ use tokio::{
 use async_trait::async_trait;
 
 use std::convert::AsRef;
+use std::fmt::Write;
 
 pub struct FileAdapter<P> {
     file_path: P,
@@ -142,18 +143,16 @@ where
 
         for (ptype, ast) in ast_map {
             for rule in ast.get_policy() {
-                policies.push_str(&format!("{}, {}\n", ptype, rule.join(",")));
+                writeln!(policies, "{}, {}", ptype, rule.join(","))
+                    .map_err(|e| AdapterError(e.into()))?;
             }
         }
 
         if let Some(ast_map) = m.get_model().get("g") {
             for (ptype, ast) in ast_map {
                 for rule in ast.get_policy() {
-                    policies.push_str(&format!(
-                        "{}, {}\n",
-                        ptype,
-                        rule.join(",")
-                    ));
+                    writeln!(policies, "{}, {}", ptype, rule.join(","))
+                        .map_err(|e| AdapterError(e.into()))?;
                 }
             }
         }

--- a/src/rbac_api.rs
+++ b/src/rbac_api.rs
@@ -623,8 +623,10 @@ mod tests {
                             .unwrap();
 
                         assert_eq!(
-                            vec!["data2_admin", "data1_admin"],
-                            ee.write().get_roles_for_user("alice", None)
+                            vec!["data1_admin", "data2_admin"],
+                            sort_unstable(
+                                ee.write().get_roles_for_user("alice", None)
+                            )
                         );
                         assert_eq!(
                             vec![String::new(); 0],
@@ -645,8 +647,10 @@ mod tests {
                             .unwrap();
 
                         assert_eq!(
-                            vec!["data2_admin", "data1_admin"],
-                            ee.write().get_roles_for_user("alice", None)
+                            vec!["data1_admin", "data2_admin"],
+                            sort_unstable(
+                                ee.write().get_roles_for_user("alice", None)
+                            )
                         );
                         assert_eq!(
                             vec!["data2_admin"],
@@ -1100,12 +1104,12 @@ mod tests {
         assert!(e.enforce(("bob", "/pen/2", "GET")).unwrap());
 
         assert_eq!(
-            vec!["/book/:id", "book_group"],
+            vec!["book_group"],
             sort_unstable(e.get_implicit_roles_for_user("/book/1", None))
         );
 
         assert_eq!(
-            vec!["/pen/:id", "pen_group"],
+            vec!["pen_group"],
             sort_unstable(e.get_implicit_roles_for_user("/pen/1", None))
         );
     }
@@ -1188,11 +1192,11 @@ mod tests {
         assert!(!e.enforce(("bob", "/book/2", "GET")).unwrap());
 
         assert_eq!(
-            vec!["*", "book_admin", "pen_admin"],
+            vec!["book_admin", "pen_admin"],
             sort_unstable(e.get_implicit_roles_for_user("alice", None))
         );
         assert_eq!(
-            vec!["*", "book_admin", "pen_admin"],
+            vec!["book_admin", "pen_admin"],
             sort_unstable(e.get_implicit_roles_for_user("bob", None))
         );
     }


### PR DESCRIPTION
This relation model is built after the Go implementation, but uses edges inside the graph to model relations instead of having each role store pointers in maps.

Edges with the `EdgeVariant::Link` are relations which in Go are modeled by the `roles` and `users` map.
Edges with the `EdgeVariant::Match` are relations which is Go are modeled by the `matched` and `matchedBy` map.

This change brings significant speedups in benchmarks when compared against the master branch.