### PR TITLE
fix: benchmark workflow cannot post comment to PR

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,6 @@
-on: [pull_request]
+on:
+  pull_request_target:
+    branches: [ master ]
 name: Benchmarks
 jobs:
   runBenchmark:
@@ -6,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-rs/issues/294
I found benchmark workflow doesn’t work well that it fails to post comment to PR.
The reason is `GITHUB_TOKEN` only has read permission to pull requests when access by forked repos, so when a new PR is coming, running workflows only has read-only permission (of course not allowed to post comment). ref: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

Luckily, GitHub has [introduced a new event type: `pull_request_target`](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/), which allows to run workflows from base branch and pass a token with write permission, so we can use it to post benchmark results to PR (ref: https://github.community/t/github-actions-are-severely-limited-on-prs/18179/17).

I modify pull_request.yml to use `pull_request_target`, now it works well:
![image](https://user-images.githubusercontent.com/40566803/175781831-ce2c2617-81ac-453a-9767-da374ef16b51.png)
