### PR TITLE
feat: replace lru with mini-moka for caching

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: '0.22.0'
           args: --no-default-features --features runtime-async-std,cached,glob,ip,watcher,logging,incremental,explain
 
       - name: Upload to codecov.io

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ritelinked = { version = "0.3.2", default-features = false, features = [
 ] }
 ip_network = { version = "0.4.1", optional = true }
 once_cell = "1.9.0"
-lru = { version = "0.7.3", optional = true }
+mini-moka = { version = "0.10", optional = true }
 parking_lot = "0.12.0"
 regex = "1.5.4"
 petgraph = "0.6"
@@ -52,7 +52,7 @@ tokio-stream = { version = "0.1.8", optional = true, default-features = false }
 default = ["runtime-tokio", "incremental"]
 
 amortized = ["ritelinked/ahash-amortized", "ritelinked/inline-more-amortized"]
-cached = ["lru"]
+cached = ["mini-moka"]
 explain = []
 glob = ["globset"]
 incremental = []
@@ -61,6 +61,9 @@ logging = ["slog", "slog-term", "slog-async"]
 runtime-async-std = ["async-std"]
 runtime-tokio = ["tokio/fs", "tokio/io-util"]
 watcher = []
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }

--- a/src/adapter/file_adapter.rs
+++ b/src/adapter/file_adapter.rs
@@ -240,10 +240,10 @@ fn load_policy_line(line: String, m: &mut dyn Model) {
     }
 }
 
-fn load_filtered_policy_line<'a>(
+fn load_filtered_policy_line(
     line: String,
     m: &mut dyn Model,
-    f: &Filter<'a>,
+    f: &Filter<'_>,
 ) -> bool {
     if line.is_empty() || line.starts_with('#') {
         return false;

--- a/src/cache/default_cache.rs
+++ b/src/cache/default_cache.rs
@@ -1,15 +1,13 @@
 use crate::cache::Cache;
-
-use lru::LruCache;
-
-use std::{borrow::Cow, hash::Hash};
+use mini_moka::sync::Cache as MokaCache;
+use std::hash::Hash;
 
 pub struct DefaultCache<K, V>
 where
     K: Eq + Hash + Send + Sync + 'static,
     V: Send + Sync + Clone + 'static,
 {
-    cache: LruCache<K, V>,
+    cache: MokaCache<K, V>,
 }
 
 impl<K, V> DefaultCache<K, V>
@@ -19,7 +17,7 @@ where
 {
     pub fn new(cap: usize) -> DefaultCache<K, V> {
         DefaultCache {
-            cache: LruCache::new(cap),
+            cache: MokaCache::new(cap as u64),
         }
     }
 }
@@ -29,68 +27,42 @@ where
     K: Eq + Hash + Send + Sync + 'static,
     V: Send + Sync + Clone + 'static,
 {
-    fn set_capacity(&mut self, cap: usize) {
-        self.cache.resize(cap);
+    fn get(&self, k: &K) -> Option<V> {
+        self.cache.get(k)
     }
 
-    fn get(&mut self, k: &K) -> Option<Cow<'_, V>> {
-        self.cache.get_mut(k).map(|x| Cow::Borrowed(&*x))
+    fn has(&self, k: &K) -> bool {
+        self.cache.contains_key(k)
     }
 
-    fn has(&mut self, k: &K) -> bool {
-        self.cache.contains(k)
+    fn set(&self, k: K, v: V) {
+        self.cache.insert(k, v);
     }
 
-    fn set(&mut self, k: K, v: V) {
-        if self.has(&k) {
-            self.cache.pop(&k);
-        }
-        self.cache.put(k, v);
-    }
-
-    fn clear(&mut self) {
-        self.cache.clear();
+    fn clear(&self) {
+        self.cache.invalidate_all();
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cached"))]
 mod tests {
     use super::*;
 
-    #[cfg(feature = "cached")]
     #[test]
     fn test_set_and_get() {
-        let mut cache = DefaultCache::new(1);
+        let cache = DefaultCache::new(1);
 
         cache.set(vec!["alice", "/data1", "read"], false);
-        assert!(
-            cache.get(&vec!["alice", "/data1", "read"])
-                == Some(Cow::Borrowed(&false))
-        );
+        assert!(cache.get(&vec!["alice", "/data1", "read"]) == Some(false));
     }
 
-    #[cfg(feature = "cached")]
     #[test]
-    fn test_capacity() {
-        let mut cache = DefaultCache::new(1);
+    fn test_has_and_clear() {
+        let cache = DefaultCache::new(1);
 
         cache.set(vec!["alice", "/data1", "read"], false);
-        cache.set(vec!["bob", "/data2", "write"], false);
+        assert!(cache.has(&vec!["alice", "/data1", "read"]));
+        cache.clear();
         assert!(!cache.has(&vec!["alice", "/data1", "read"]));
-        assert!(cache.has(&vec!["bob", "/data2", "write"]));
-    }
-
-    #[cfg(feature = "cached")]
-    #[test]
-    fn test_set_capacity() {
-        let mut cache = DefaultCache::new(1);
-        cache.set_capacity(2);
-
-        cache.set(vec!["alice", "/data1", "read"], false);
-        cache.set(vec!["bob", "/data2", "write"], false);
-        cache.set(vec!["unknow", "/data3", "read_write"], false);
-        assert!(!cache.has(&vec!["alice", "/data1", "read"]));
-        assert!(cache.has(&vec!["bob", "/data2", "write"]));
-        assert!(cache.has(&vec!["unknow", "/data3", "read_write"]));
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use std::{borrow::Cow, hash::Hash};
+use std::hash::Hash;
 
 pub mod default_cache;
 
@@ -12,9 +12,8 @@ where
     K: Eq + Hash,
     V: Clone,
 {
-    fn set_capacity(&mut self, c: usize);
-    fn get(&mut self, k: &K) -> Option<Cow<'_, V>>;
-    fn has(&mut self, k: &K) -> bool;
-    fn set(&mut self, k: K, v: V);
-    fn clear(&mut self);
+    fn get(&self, k: &K) -> Option<V>;
+    fn has(&self, k: &K) -> bool;
+    fn set(&self, k: K, v: V);
+    fn clear(&self);
 }

--- a/src/cached_api.rs
+++ b/src/cached_api.rs
@@ -9,5 +9,4 @@ where
 {
     fn get_mut_cache(&mut self) -> &mut dyn Cache<K, V>;
     fn set_cache(&mut self, cache: Box<dyn Cache<K, V>>);
-    fn set_capacity(&mut self, cap: usize);
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -42,6 +42,7 @@ impl<T> TryIntoModel for Option<T>
 where
     T: TryIntoModel,
 {
+    #[allow(clippy::box_default)]
     async fn try_into_model(self) -> Result<Box<dyn Model>> {
         if let Some(m) = self {
             m.try_into_model().await

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -211,6 +211,7 @@ impl Enforcer {
 
 #[async_trait]
 impl CoreApi for Enforcer {
+    #[allow(clippy::box_default)]
     async fn new_raw<M: TryIntoModel, A: TryIntoAdapter>(
         m: M,
         a: A,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,7 +31,7 @@ macro_rules! register_g_function {
             $enforcer.engine.register_fn(
                 $fname,
                 move |arg1: ImmutableString, arg2: ImmutableString| {
-                    rm.write().has_link(&arg1, &arg2, None)
+                    rm.read().has_link(&arg1, &arg2, None)
                 },
             );
         } else if count == 3 {
@@ -40,7 +40,7 @@ macro_rules! register_g_function {
                 move |arg1: ImmutableString,
                       arg2: ImmutableString,
                       arg3: ImmutableString| {
-                    rm.write().has_link(&arg1, &arg2, Some(&arg3))
+                    rm.read().has_link(&arg1, &arg2, Some(&arg3))
                 },
             );
         } else {

--- a/src/rbac/default_role_manager.rs
+++ b/src/rbac/default_role_manager.rs
@@ -252,12 +252,7 @@ impl RoleManager for DefaultRoleManager {
         Ok(())
     }
 
-    fn has_link(
-        &mut self,
-        name1: &str,
-        name2: &str,
-        domain: Option<&str>,
-    ) -> bool {
+    fn has_link(&self, name1: &str, name2: &str, domain: Option<&str>) -> bool {
         if name1 == name2 {
             return true;
         }
@@ -332,7 +327,7 @@ impl RoleManager for DefaultRoleManager {
         res
     }
 
-    fn get_roles(&mut self, name: &str, domain: Option<&str>) -> Vec<String> {
+    fn get_roles(&self, name: &str, domain: Option<&str>) -> Vec<String> {
         let matched_domains = self.matched_domains(domain);
 
         let res = matched_domains.into_iter().fold(

--- a/src/rbac/default_role_manager.rs
+++ b/src/rbac/default_role_manager.rs
@@ -273,7 +273,7 @@ impl RoleManager for DefaultRoleManager {
 
         #[cfg(feature = "cached")]
         if let Some(res) = self.cache.get(&cache_key) {
-            return res.into_owned();
+            return res;
         }
 
         let matched_domains = self.matched_domains(domain);

--- a/src/rbac/role_manager.rs
+++ b/src/rbac/role_manager.rs
@@ -16,12 +16,7 @@ pub trait RoleManager: Send + Sync {
         name2: &str,
         domain: Option<&str>,
     ) -> Result<()>;
-    fn has_link(
-        &mut self,
-        name1: &str,
-        name2: &str,
-        domain: Option<&str>,
-    ) -> bool;
-    fn get_roles(&mut self, name: &str, domain: Option<&str>) -> Vec<String>;
+    fn has_link(&self, name1: &str, name2: &str, domain: Option<&str>) -> bool;
+    fn get_roles(&self, name: &str, domain: Option<&str>) -> Vec<String>;
     fn get_users(&self, name: &str, domain: Option<&str>) -> Vec<String>;
 }


### PR DESCRIPTION
Replace the `lru` library with `mini-moka` for caching. This allows the API to take `&self` instead of `&mut self` for most operations.

This also allows to only take a read lock when executing `g` functions. 