### PR TITLE
bugfix: defer call `load_policy`

### DIFF
--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -262,9 +262,7 @@ impl CoreApi for Enforcer {
         m: M,
         a: A,
     ) -> Result<Self> {
-        let mut e = Self::new_raw(m, a).await?;
-        e.load_policy().await?;
-        Ok(e)
+        Ok(Self::new_raw(m, a).await?)
     }
 
     #[inline]
@@ -380,6 +378,7 @@ impl CoreApi for Enforcer {
     /// #[async_std::main]
     /// async fn main() -> Result<()> {
     ///     let mut e = Enforcer::new("examples/basic_model.conf", "examples/basic_policy.csv").await?;
+    ///     e.load_policy().await.unwrap();
     ///     assert_eq!(true, e.enforce(("alice", "data1", "read"))?);
     ///     Ok(())
     /// }
@@ -388,6 +387,8 @@ impl CoreApi for Enforcer {
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
     ///     let mut e = Enforcer::new("examples/basic_model.conf", "examples/basic_policy.csv").await?;
+    ///     e.load_policy().await.unwrap();
+    ///
     ///     assert_eq!(true, e.enforce(("alice", "data1", "read"))?);
     ///
     ///     Ok(())
@@ -604,6 +605,7 @@ mod tests {
         let file = FileAdapter::new("examples/basic_policy.csv");
         let mem = MemoryAdapter::default();
         let mut e = Enforcer::new(m, file).await.unwrap();
+        e.load_policy().await.unwrap();
         // this should fail since FileAdapter has basically no add_policy
         assert!(e
             .adapter
@@ -648,7 +650,8 @@ mod tests {
         );
 
         let adapter = FileAdapter::new("examples/keymatch_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
         assert_eq!(
             true,
             e.enforce(("alice", "/alice_data/resource1", "GET"))
@@ -748,7 +751,8 @@ mod tests {
         );
 
         let adapter = FileAdapter::new("examples/keymatch_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
         assert_eq!(
             true,
             e.enforce(("alice", "/alice_data/resource2", "POST"))
@@ -780,6 +784,7 @@ mod tests {
 
         let adapter = MemoryAdapter::default();
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
         e.add_permission_for_user(
             "alice",
             vec!["data1", "invalid"]
@@ -815,6 +820,7 @@ mod tests {
 
         let adapter = MemoryAdapter::default();
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
         e.add_permission_for_user(
             "alice",
             vec!["data1", "read"]
@@ -888,6 +894,7 @@ mod tests {
 
         let adapter = MemoryAdapter::default();
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
         e.add_permission_for_user(
             "alice",
             vec!["data1", "read"]
@@ -933,7 +940,8 @@ mod tests {
             .unwrap();
 
         let adapter = FileAdapter::new("examples/ipmatch_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert!(e.enforce(("192.168.2.123", "data1", "read")).unwrap());
 
@@ -974,6 +982,7 @@ mod tests {
 
         let adapter = FileAdapter::new("examples/basic_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
         e.enable_auto_save(false);
         e.remove_policy(
             vec!["alice", "data1", "read"]
@@ -1030,6 +1039,7 @@ mod tests {
 
         let adapter = MemoryAdapter::default();
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
         e.enable_auto_build_role_links(false);
         e.build_role_links().unwrap();
         assert_eq!(false, e.enforce(("user501", "data9", "read")).unwrap());
@@ -1050,6 +1060,7 @@ mod tests {
             .unwrap();
         let adapter1 = FileAdapter::new("examples/basic_policy.csv");
         let mut e = Enforcer::new(m1, adapter1).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(false, e.enforce(("root", "data1", "read")).unwrap());
 
@@ -1078,6 +1089,7 @@ mod tests {
             .unwrap();
         let adapter1 = FileAdapter::new("examples/basic_policy.csv");
         let mut e = Enforcer::new(m1, adapter1).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(true, e.enforce(("alice", "data1", "read")).unwrap());
         assert_eq!(false, e.enforce(("alice", "data1", "write")).unwrap());
@@ -1111,6 +1123,7 @@ mod tests {
             .unwrap();
         let adapter1 = FileAdapter::new("examples/keymatch_policy.csv");
         let mut e = Enforcer::new(m1, adapter1).await.unwrap();
+        e.load_policy().await.unwrap();
 
         e.add_function(
             "keyMatchCustom",
@@ -1191,6 +1204,7 @@ mod tests {
         )
         .await
         .unwrap();
+        e.load_policy().await.unwrap();
 
         let new_rm = Arc::new(RwLock::new(DefaultRoleManager::new(10)));
 
@@ -1295,6 +1309,7 @@ mod tests {
         let a = MemoryAdapter::default();
 
         let mut e = Enforcer::new(m, a).await.unwrap();
+        e.load_policy().await.unwrap();
 
         e.add_policy(
             vec![r#""admin""#, "post", "write"]

--- a/src/management_api.rs
+++ b/src/management_api.rs
@@ -450,6 +450,7 @@ mod tests {
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(vec!["data2_admin"], e.get_roles_for_user("alice", None));
         assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob", None));
@@ -569,6 +570,7 @@ mod tests {
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(
             vec![
@@ -661,7 +663,8 @@ mod tests {
             .unwrap();
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(
             vec![
@@ -887,7 +890,8 @@ mod tests {
             .unwrap();
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(
             vec!["alice", "bob", "data2_admin"],
@@ -914,6 +918,7 @@ mod tests {
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(
             vec![
@@ -1086,6 +1091,7 @@ mod tests {
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(vec!["data2_admin"], e.get_roles_for_user("alice", None));
         assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob", None));

--- a/src/model/default_model.rs
+++ b/src/model/default_model.rs
@@ -405,7 +405,8 @@ mod tests {
             .unwrap();
 
         let adapter = FileAdapter::new("examples/basic_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert!(e.enforce(("alice", "data1", "read")).unwrap());
         assert!(!e.enforce(("alice", "data1", "write")).unwrap());
@@ -432,7 +433,8 @@ mod tests {
             .unwrap();
 
         let adapter = MemoryAdapter::default();
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert!(!e.enforce(("alice", "data1", "read")).unwrap());
         assert!(!e.enforce(("alice", "data1", "write")).unwrap());
@@ -459,7 +461,8 @@ mod tests {
             .unwrap();
 
         let adapter = FileAdapter::new("examples/basic_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert!(e.enforce(("alice", "data1", "read")).unwrap());
         assert!(e.enforce(("bob", "data2", "write")).unwrap());
@@ -490,7 +493,8 @@ mod tests {
             .unwrap();
 
         let adapter = MemoryAdapter::default();
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert!(!e.enforce(("alice", "data1", "read")).unwrap());
         assert!(!e.enforce(("bob", "data2", "write")).unwrap());
@@ -523,7 +527,8 @@ mod tests {
 
         let adapter =
             FileAdapter::new("examples/basic_without_users_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert!(e.enforce(("data1", "read")).unwrap());
         assert!(!e.enforce(("data1", "write")).unwrap());
@@ -549,7 +554,8 @@ mod tests {
 
         let adapter =
             FileAdapter::new("examples/basic_without_resources_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert!(e.enforce(("alice", "read")).unwrap());
         assert!(e.enforce(("bob", "write")).unwrap());
@@ -572,7 +578,8 @@ mod tests {
             .unwrap();
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(true, e.enforce(("alice", "data1", "read")).unwrap());
         assert_eq!(false, e.enforce(("alice", "data1", "write")).unwrap());
@@ -602,7 +609,8 @@ mod tests {
 
         let adapter =
             FileAdapter::new("examples/rbac_with_resource_roles_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(true, e.enforce(("alice", "data1", "read")).unwrap());
         assert_eq!(true, e.enforce(("alice", "data1", "write")).unwrap());
@@ -630,7 +638,8 @@ mod tests {
                 .unwrap();
 
         let adapter = FileAdapter::new("examples/rbac_with_domains_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(
             true,
@@ -683,6 +692,8 @@ mod tests {
 
         let adapter = MemoryAdapter::default();
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
+
         e.add_policy(
             vec!["admin", "domain1", "data1", "read"]
                 .iter()
@@ -875,6 +886,7 @@ mod tests {
 
         let adapter = FileAdapter::new("examples/rbac_with_domains_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         e.add_policy(
             vec!["admin", "domain3", "data1", "read"]
@@ -949,7 +961,8 @@ mod tests {
             .unwrap();
 
         let adapter = FileAdapter::new("examples/rbac_with_deny_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(true, e.enforce(("alice", "data1", "read")).unwrap());
         assert_eq!(false, e.enforce(("alice", "data1", "write")).unwrap());
@@ -977,7 +990,8 @@ mod tests {
                 .unwrap();
 
         let adapter = FileAdapter::new("examples/rbac_with_deny_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(false, e.enforce(("alice", "data2", "write")).unwrap());
     }
@@ -998,6 +1012,7 @@ mod tests {
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         e.add_grouping_policy(
             vec!["bob", "data2_admin", "custom_data"]
@@ -1053,7 +1068,8 @@ mod tests {
         .unwrap();
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(true, e.enforce(("alice", "data1", "read")).unwrap());
         assert_eq!(false, e.enforce(("alice", "data1", "write")).unwrap());
@@ -1082,7 +1098,8 @@ mod tests {
             .unwrap();
 
         let adapter = MemoryAdapter::default();
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         #[derive(Serialize, Hash)]
         pub struct Book<'a> {

--- a/src/rbac_api.rs
+++ b/src/rbac_api.rs
@@ -405,6 +405,7 @@ mod tests {
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(vec!["data2_admin"], e.get_roles_for_user("alice", None));
         assert_eq!(vec![String::new(); 0], e.get_roles_for_user("bob", None));
@@ -528,7 +529,9 @@ mod tests {
             .unwrap();
 
         let adapter = FileAdapter::new("examples/rbac_policy.csv");
-        let e = Arc::new(RwLock::new(Enforcer::new(m, adapter).await.unwrap()));
+        let mut e_entity = Enforcer::new(m, adapter).await.unwrap();
+        e_entity.load_policy().await.unwrap();
+        let e = Arc::new(RwLock::new(e_entity));
         let ee = e.clone();
 
         assert_eq!(
@@ -792,6 +795,7 @@ mod tests {
         let adapter =
             FileAdapter::new("examples/basic_without_resources_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(true, e.enforce(("alice", "read")).unwrap());
         assert_eq!(false, e.enforce(("alice", "write")).unwrap());
@@ -912,6 +916,7 @@ mod tests {
         let adapter =
             FileAdapter::new("examples/rbac_with_hierarchy_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(
             vec![vec!["alice", "data1", "read"]],
@@ -949,6 +954,7 @@ mod tests {
         let adapter =
             FileAdapter::new("examples/rbac_with_hierarchy_policy.csv");
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(
             vec![vec!["alice", "data1", "read"]],
@@ -991,7 +997,8 @@ mod tests {
 
         let adapter =
             FileAdapter::new("examples/rbac_with_hierarchy_policy.csv");
-        let e = Enforcer::new(m, adapter).await.unwrap();
+        let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(
             vec!["alice"],
@@ -1056,6 +1063,7 @@ mod tests {
             "examples/rbac_with_hierarchy_with_domains_policy.csv",
         );
         let mut e = Enforcer::new(m, adapter).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert_eq!(
             vec![
@@ -1085,6 +1093,7 @@ mod tests {
         )
         .await
         .unwrap();
+        e.load_policy().await.unwrap();
 
         use crate::model::key_match2;
 
@@ -1130,6 +1139,7 @@ mod tests {
         )
         .await
         .unwrap();
+        e.load_policy().await.unwrap();
 
         use crate::function_map::key_match;
 
@@ -1174,6 +1184,7 @@ mod tests {
         )
         .await
         .unwrap();
+        e.load_policy().await.unwrap();
 
         use crate::model::key_match;
 
@@ -1225,6 +1236,7 @@ mod tests {
         let a = MemoryAdapter::default();
 
         let mut e = Enforcer::new(m, a).await.unwrap();
+        e.load_policy().await.unwrap();
 
         assert!(e
             .add_policy(vec![


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-rs/issues/304

in casbin-rs, there is no `FilterAdapter`, all adapters implement trait `adapter` which has method `load_filtered_policy`, thus we cannot determine if we can call `load_policy` in `Enforcer:new` by object type, all we can do is not call `load_policy` or `load_filtered_policy` until use.