### PR TITLE
feat: add `new_filtered_adapter()` to FileAdapter to make it act as a FilterAdapter.

### DIFF
--- a/src/adapter/file_adapter.rs
+++ b/src/adapter/file_adapter.rs
@@ -51,8 +51,15 @@ where
         }
     }
 
+    pub fn new_filtered_adapter(p: P) -> FileAdapter<P> {
+        FileAdapter {
+            file_path: p,
+            is_filtered: true,
+        }
+    }
+
     async fn load_policy_file(
-        &self,
+        &mut self,
         m: &mut dyn Model,
         handler: LoadPolicyFileHandler,
     ) -> Result<()> {
@@ -110,7 +117,8 @@ impl<P> Adapter for FileAdapter<P>
 where
     P: AsRef<Path> + Send + Sync,
 {
-    async fn load_policy(&self, m: &mut dyn Model) -> Result<()> {
+    async fn load_policy(&mut self, m: &mut dyn Model) -> Result<()> {
+        self.is_filtered = false;
         self.load_policy_file(m, load_policy_line).await?;
         Ok(())
     }

--- a/src/adapter/memory_adapter.rs
+++ b/src/adapter/memory_adapter.rs
@@ -15,7 +15,8 @@ pub struct MemoryAdapter {
 
 #[async_trait]
 impl Adapter for MemoryAdapter {
-    async fn load_policy(&self, m: &mut dyn Model) -> Result<()> {
+    async fn load_policy(&mut self, m: &mut dyn Model) -> Result<()> {
+        self.is_filtered = false;
         for line in self.policy.iter() {
             let sec = &line[0];
             let ptype = &line[1];

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -20,7 +20,7 @@ pub struct Filter<'a> {
 
 #[async_trait]
 pub trait Adapter: Send + Sync {
-    async fn load_policy(&self, m: &mut dyn Model) -> Result<()>;
+    async fn load_policy(&mut self, m: &mut dyn Model) -> Result<()>;
     async fn load_filtered_policy<'a>(
         &mut self,
         m: &mut dyn Model,

--- a/src/adapter/null_adapter.rs
+++ b/src/adapter/null_adapter.rs
@@ -10,7 +10,7 @@ pub struct NullAdapter;
 
 #[async_trait]
 impl Adapter for NullAdapter {
-    async fn load_policy(&self, _m: &mut dyn Model) -> Result<()> {
+    async fn load_policy(&mut self, _m: &mut dyn Model) -> Result<()> {
         Ok(())
     }
 

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -416,7 +416,11 @@ impl CoreApi for Enforcer {
         a: A,
     ) -> Result<Self> {
         let mut e = Self::new_raw(m, a).await?;
-        e.load_policy().await?;
+        
+        // Do not initialize the full policy when using a filtered adapter
+        if !e.adapter.is_filtered() {
+            e.load_policy().await?;
+        }
         Ok(e)
     }
 
@@ -1373,9 +1377,10 @@ mod tests {
         tokio::test
     )]
     async fn test_filtered_file_adapter() {
+        let adapter = FileAdapter::new_filtered_adapter("examples/rbac_with_domains_policy.csv");
         let mut e = Enforcer::new(
             "examples/rbac_with_domains_model.conf",
-            "examples/rbac_with_domains_policy.csv",
+            adapter
         )
         .await
         .unwrap();


### PR DESCRIPTION
fix: #304

add `new_filtered_adapter()` to FileAdapter to make it act as a FilterAdapter.

And does not automatically load the policy when using the filter adapter.