### PR TITLE
feat: replace `ritelinked` with `hashlink`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,9 @@
 name: CI
-
 on:
   pull_request:
   push:
     branches:
       - master
-
 jobs:
   build:
     name: Auto Build CI
@@ -14,26 +12,22 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [beta, stable]
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master
-
       - name: Install Rust toolchain ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain:  ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
           override: true
-
       - name: Install wasm32-unknown-unknown for ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain:  ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust }}
           target: wasm32-unknown-unknown
           override: true
-     
       # Work around https://github.com/actions/cache/issues/403 by using GNU tar
       # instead of BSD tar.
       - name: Install GNU tar
@@ -41,61 +35,51 @@ jobs:
         run: |
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}-${{ secrets.CACHE_VERSION }}
-
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
           path: ~/.cargo/git
           key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}-${{ secrets.CACHE_VERSION }}
-
       - name: Cache cargo build
         uses: actions/cache@v1
         with:
           path: target
           key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}-${{ secrets.CACHE_VERSION }}
-
       - name: Release build async-std
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --no-default-features --features runtime-async-std,cached,glob,ip,watcher,logging,incremental,explain
-
       - name: Release build tokio
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --no-default-features --features runtime-tokio,cached,glob,ip,watcher,logging,incremental,explain
-
       - name: Cargo Test For All Features Using async-std
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features runtime-async-std,amortized,cached,glob,ip,watcher,logging,incremental,explain
-
+          args: --no-default-features --features runtime-async-std,cached,glob,ip,watcher,logging,incremental,explain
       - name: Cargo Test For All Features Using tokio
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features runtime-tokio,amortized,cached,glob,ip,watcher,logging,incremental,explain
-
+          args: --no-default-features --features runtime-tokio,cached,glob,ip,watcher,logging,incremental,explain
       - name: Cargo Check Wasm
         uses: actions-rs/cargo@v1
         with:
-          command:  check
-          args: --target wasm32-unknown-unknown --no-default-features --features runtime-async-std,amortized,cached,glob,ip,watcher,logging,incremental
-
+          command: check
+          args: --target wasm32-unknown-unknown --no-default-features --features runtime-async-std,cached,glob,ip,watcher,logging,incremental
       - name: Clippy warnings
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings
-
       - name: Cargo Fmt Check
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,7 @@ async-std = { version = "1.10.0", optional = true }
 
 async-trait = "0.1.52"
 globset = { version = "0.4.8", optional = true }
-ritelinked = { version = "0.3.2", default-features = false, features = [
-  "ahash",
-  "inline-more",
-] }
+hashlink = "0.9.0"
 ip_network = { version = "0.4.1", optional = true }
 once_cell = "1.9.0"
 mini-moka = { version = "0.10", optional = true }
@@ -51,7 +48,6 @@ tokio-stream = { version = "0.1.8", optional = true, default-features = false }
 [features]
 default = ["runtime-tokio", "incremental"]
 
-amortized = ["ritelinked/ahash-amortized", "ritelinked/inline-more-amortized"]
 cached = ["mini-moka"]
 explain = []
 glob = ["globset"]

--- a/src/adapter/memory_adapter.rs
+++ b/src/adapter/memory_adapter.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use ritelinked::LinkedHashSet;
+use hashlink::LinkedHashSet;
 
 #[derive(Default)]
 pub struct MemoryAdapter {

--- a/src/model/assertion.rs
+++ b/src/model/assertion.rs
@@ -7,8 +7,8 @@ use crate::{
 #[cfg(feature = "incremental")]
 use crate::emitter::EventData;
 
+use hashlink::{LinkedHashMap, LinkedHashSet};
 use parking_lot::RwLock;
-use ritelinked::{LinkedHashMap, LinkedHashSet};
 
 use std::sync::Arc;
 

--- a/src/model/default_model.rs
+++ b/src/model/default_model.rs
@@ -11,7 +11,7 @@ use crate::{
 use crate::emitter::EventData;
 
 use parking_lot::RwLock;
-use ritelinked::{LinkedHashMap, LinkedHashSet};
+use hashlink::{LinkedHashMap, LinkedHashSet};
 
 #[cfg(all(feature = "runtime-async-std", not(target_arch = "wasm32")))]
 use async_std::path::Path as ioPath;

--- a/src/model/default_model.rs
+++ b/src/model/default_model.rs
@@ -10,8 +10,8 @@ use crate::{
 #[cfg(feature = "incremental")]
 use crate::emitter::EventData;
 
-use parking_lot::RwLock;
 use hashlink::{LinkedHashMap, LinkedHashSet};
+use parking_lot::RwLock;
 
 #[cfg(all(feature = "runtime-async-std", not(target_arch = "wasm32")))]
 use async_std::path::Path as ioPath;


### PR DESCRIPTION
Replaces the dependency on `ritelinked` with the more popular and maintained `hashlink` (of which `ritelinked` was originally just a fork of).  Also removes the `amortized` feature since that applied exclusively to `ritelinked`.

Closes #326 