### PR TITLE
feat: implement string adapter for model and policy

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - dev
+  workflow_dispatch:
 
 jobs:
   cover:

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -17,6 +17,10 @@ use std::{
 pub trait TryIntoModel: Send + Sync {
     async fn try_into_model(self) -> Result<Box<dyn Model>>;
 }
+#[async_trait]
+pub trait TryIntoModelFromStr:Send + Sync {
+    async fn try_into_model_from_str(self) -> Result<Box<dyn Model>>;
+}
 
 #[async_trait]
 pub trait TryIntoAdapter: Send + Sync {
@@ -34,6 +38,12 @@ impl TryIntoModel for &'static str {
         {
             Ok(Box::new(DefaultModel::from_str(self).await?))
         }
+    }
+}
+#[async_trait]
+impl TryIntoModelFromStr for &'static str {
+    async fn try_into_model_from_str(self)->Result<Box<dyn Model>>{
+        Ok(Box::new(DefaultModel::from_str(self).await?))
     }
 }
 

--- a/src/core_api.rs
+++ b/src/core_api.rs
@@ -1,9 +1,8 @@
 use crate::{
     enforcer::EnforceContext, model::OperatorFunction, Adapter, Effector,
     EnforceArgs, Event, EventEmitter, Filter, Model, Result, RoleManager,
-    TryIntoAdapter, TryIntoModel,
+    TryIntoAdapter, TryIntoModel,convert::TryIntoModelFromStr
 };
-
 #[cfg(feature = "watcher")]
 use crate::Watcher;
 
@@ -26,7 +25,19 @@ pub trait CoreApi: Send + Sync {
     ) -> Result<Self>
     where
         Self: Sized;
+    async fn new_raw_from_str<M: TryIntoModelFromStr, A: TryIntoAdapter>(
+        m: M,
+        a: A,
+    ) -> Result<Self>
+    where
+        Self: Sized;
     async fn new<M: TryIntoModel, A: TryIntoAdapter>(
+        m: M,
+        a: A,
+    ) -> Result<Self>
+    where
+        Self: Sized;
+    async fn new_from_str<M: TryIntoModelFromStr, A: TryIntoAdapter>(
         m: M,
         a: A,
     ) -> Result<Self>


### PR DESCRIPTION
This pull request introduces a new trait `TryIntoModelFromStr` and integrates it into the existing codebase. The main changes include adding the new trait, implementing it for `&'static str`, and updating the `CoreApi` and `Enforcer` to support the new trait. Additionally, new test cases have been added to ensure the functionality works as expected.

### Introduction of `TryIntoModelFromStr` trait:

* [`src/convert.rs`](diffhunk://#diff-d42cae02d6ab6561d7a3d9a4d5538b03cdb33e075dfe41a89e70fd8206d9eaabR20-R23): Added `TryIntoModelFromStr` trait and implemented it for `&'static str`
### Integration into `CoreApi`:

* [`src/core_api.rs`](diffhunk://#diff-8de5aebda1ce42c2b44f0007fe6062c4c137f0ab56cf2144ea9bb2e79799f342L4-L6): Updated imports and added methods `new_raw_from_str` and `new_from_str` to the `CoreApi` trait.

### Integration into `Enforcer`:

* [`src/enforcer.rs`](diffhunk://#diff-75edc06145c10082539e06c36ac6af9eda384e2f312d87bb5c60d451a08c605aL3-R3): Updated imports and implemented the new methods `new_raw_from_str` and `new_from_str` in the `Enforcer` struct. 

### Testing:

* [`src/enforcer.rs`]: Added a new test case `test_get_and_set_model_from_str` to validate the new functionality.