### PR TITLE
feat: add StringAdapter to file adapter module

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -4,11 +4,15 @@ use async_trait::async_trait;
 pub mod file_adapter;
 pub mod memory_adapter;
 pub mod null_adapter;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod string_adapater;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use file_adapter::FileAdapter;
 pub use memory_adapter::MemoryAdapter;
 pub use null_adapter::NullAdapter;
+#[cfg(not(target_arch = "wasm32"))]
+pub use string_adapater::StringAdapter;
 
 use crate::{model::Model, Result};
 

--- a/src/adapter/string_adapater.rs
+++ b/src/adapter/string_adapater.rs
@@ -1,0 +1,156 @@
+pub struct StringAdapter {
+    policy_string: String,
+    is_filtered: bool,
+}
+
+impl StringAdapter {
+    pub fn new(policy_string: String) -> Self {
+        StringAdapter {
+            policy_string,
+            is_filtered: false,
+        }
+    }
+
+    pub fn new_filtered_adapter(policy_string: String) -> Self {
+        StringAdapter {
+            policy_string,
+            is_filtered: true,
+        }
+    }
+
+    fn load_policy_from_string(
+        &mut self,
+        m: &mut dyn Model,
+        handler: LoadPolicyFileHandler,
+    ) -> Result<()> {
+        let lines = self.policy_string.lines();
+        for line in lines {
+            handler(line.to_string(), m);
+        }
+        Ok(())
+    }
+
+    fn load_filtered_policy_from_string<'a>(
+        &mut self,
+        m: &mut dyn Model,
+        filter: Filter<'a>,
+        handler: LoadFilteredPolicyFileHandler<'a>,
+    ) -> Result<bool> {
+        let mut is_filtered = false;
+        let lines = self.policy_string.lines();
+        for line in lines {
+            if handler(line.to_string(), m, &filter) {
+                is_filtered = true;
+            }
+        }
+        Ok(is_filtered)
+    }
+
+    fn save_policy_to_string(&mut self, policies: String) -> Result<()> {
+        self.policy_string = policies;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Adapter for StringAdapter {
+    async fn load_policy(&mut self, m: &mut dyn Model) -> Result<()> {
+        self.is_filtered = false;
+        self.load_policy_from_string(m, load_policy_line)?;
+        Ok(())
+    }
+
+    async fn load_filtered_policy<'a>(
+        &mut self,
+        m: &mut dyn Model,
+        f: Filter<'a>,
+    ) -> Result<()> {
+        self.is_filtered = self.load_filtered_policy_from_string(
+            m,
+            f,
+            load_filtered_policy_line,
+        )?;
+        Ok(())
+    }
+
+    async fn save_policy(&mut self, m: &mut dyn Model) -> Result<()> {
+        let mut policies = String::new();
+        let ast_map = m.get_model().get("p").ok_or_else(|| {
+            ModelError::P("Missing policy definition in conf file".to_owned())
+        })?;
+
+        for (ptype, ast) in ast_map {
+            for rule in ast.get_policy() {
+                writeln!(policies, "{},{}", ptype, rule.join(","))
+                    .map_err(|e| AdapterError(e.into()))?;
+            }
+        }
+
+        if let Some(ast_map) = m.get_model().get("g") {
+            for (ptype, ast) in ast_map {
+                for rule in ast.get_policy() {
+                    writeln!(policies, "{},{}", ptype, rule.join(","))
+                        .map_err(|e| AdapterError(e.into()))?;
+                }
+            }
+        }
+
+        self.save_policy_to_string(policies)?;
+        Ok(())
+    }
+
+    async fn clear_policy(&mut self) -> Result<()> {
+        self.save_policy_to_string(String::new())?;
+        Ok(())
+    }
+
+    async fn add_policy(
+        &mut self,
+        _sec: &str,
+        _ptype: &str,
+        _rule: Vec<String>,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    async fn add_policies(
+        &mut self,
+        _sec: &str,
+        _ptype: &str,
+        _rules: Vec<Vec<String>>,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    async fn remove_policy(
+        &mut self,
+        _sec: &str,
+        _ptype: &str,
+        _rule: Vec<String>,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    async fn remove_policies(
+        &mut self,
+        _sec: &str,
+        _ptype: &str,
+        _rules: Vec<Vec<String>>,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    async fn remove_filtered_policy(
+        &mut self,
+        _sec: &str,
+        _ptype: &str,
+        _field_index: usize,
+        _field_values: Vec<String>,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn is_filtered(&self) -> bool {
+        self.is_filtered
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,9 @@ pub mod prelude;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use adapter::FileAdapter;
+#[cfg(not(target_arch = "wasm32"))]
+pub use adapter::StringAdapter;
 pub use adapter::{Adapter, Filter, MemoryAdapter, NullAdapter};
-
 #[cfg(feature = "cached")]
 pub use cache::{Cache, DefaultCache};
 #[cfg(feature = "cached")]


### PR DESCRIPTION
This pull request introduces a new `StringAdapter` to handle policy strings directly, along with necessary integrations and updates to the existing codebase. The most important changes include the addition of the `StringAdapter` struct and its implementation, updates to the `adapter` module to include the new adapter, and modifications to the main library file to use the new adapter.


### Introduction of `StringAdapter`:

* [`src/adapter/file_adapter.rs`](diffhunk://#diff-ed98e42b0ef043a8be39d1927d0735624e712d7ff91730e22b6ab11830b097ddR293-R449): Added the `StringAdapter` struct with methods to load, save, and clear policies from a string, and implemented the `Adapter` trait for it.

### Module updates:

* [`src/adapter/mod.rs`](diffhunk://#diff-f954921da1dcfdd2896c121c01c5401e184c35d963e4a37339325c529c7d59daL9-R9): Updated to include `StringAdapter` in the list of exported adapters.

### Library updates:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L35-R37): Modified to conditionally export `StringAdapter` along with other adapters.