### PR TITLE
feat: Implement key_match4/key_match5 functions and generic EnforceArgs<T>

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -114,9 +114,12 @@ pub trait EnforceArgs {
     fn cache_key(&self) -> u64;
 }
 
-impl EnforceArgs for Vec<String> {
+impl<T> EnforceArgs for Vec<T>
+where
+    T: Into<Dynamic> + Hash + Clone,
+{
     fn try_into_vec(self) -> Result<Vec<Dynamic>> {
-        Ok(self.into_iter().map(Dynamic::from).collect())
+        Ok(self.into_iter().map(|x| x.into()).collect())
     }
 
     fn cache_key(&self) -> u64 {

--- a/src/enforcer.rs
+++ b/src/enforcer.rs
@@ -365,6 +365,15 @@ impl Enforcer {
             OperatorFunction::Arg3(func) => {
                 engine.register_fn(key, func);
             }
+            OperatorFunction::Arg4(func) => {
+                engine.register_fn(key, func);
+            }
+            OperatorFunction::Arg5(func) => {
+                engine.register_fn(key, func);
+            }
+            OperatorFunction::Arg6(func) => {
+                engine.register_fn(key, func);
+            }
         }
     }
 


### PR DESCRIPTION
### Type  
- Feature  

### Changes  
1. **Added `key_match4` and `key_match5` functions**  
   - Implemented new pattern-matching logic for extended policy rule support.  
   - Converted inline comments to Rust doc comments (`///`) for improved API documentation.  

2. **Generic implementation for `EnforceArgs`**  
   - Refactored `EnforceArgs` implementation from `Vec<String>` to generic `Vec<T>`.  
   - Enables compatibility with any vector type while maintaining type safety.  
