### PR TITLE
fix: fix wrong cap range in push_index_if_explain marco

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -80,7 +80,7 @@ macro_rules! register_g_function {
 macro_rules! push_index_if_explain {
     ($this:ident) => {{
         #[cfg(feature = "explain")]
-        if $this.cap > 1 {
+        if $this.cap > 0 {
             $this.expl.push($this.idx);
         }
     }};


### PR DESCRIPTION
* [`src/macros.rs`](diffhunk://#diff-315c02cd05738da173861537577d159833f70f79cfda8cd7cf1a0d7a28ace31bL83-R83): Changed the condition in the `push_index_if_explain` macro from checking if `cap` is greater than 1 to checking if `cap` is greater than 0.