### PR TITLE
chore: add SECURITY.md and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.toml]
+indent_style = space
+indent_size = 2
+
+[*.{yaml,yml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The Apache Software Foundation takes security issues very seriously. If you discover a security vulnerability, please report it responsibly.
+
+**Please do NOT create a public GitHub issue for security vulnerabilities.**
+
+Instead, please send your report to the Apache Security Team:
+
+- Email: [security@apache.org](mailto:security@apache.org)
+
+For more information on how to report vulnerabilities to the Apache Software Foundation, please see the [ASF Security page](https://www.apache.org/security/).
+
+## Supported Versions
+
+Please refer to the [releases page](../../releases) for currently supported versions.


### PR DESCRIPTION
## Summary

Add community health files to improve project governance and contributor experience.

## Changes

- **SECURITY.md**: Add Apache security vulnerability reporting policy pointing to security@apache.org per ASF Security guidelines
- **.editorconfig**: Add editor configuration for consistent formatting (indent style, trailing whitespace, final newline)

## Testing

N/A — documentation/configuration files only, no code changes.