### PR TITLE
fix: restore the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ This project exists thanks to all the people who contribute.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=apache/casbin-rs&type=Date)](https://star-history.com/#apache/casbin-rs&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=apache/casbin-rs&type=Date)](https://star-history.dera.page/#apache/casbin-rs&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken due to the upstream GitHub stargazer API restrictions, so it no longer renders.

This PR switches the chart to a working provider so contributors and visitors can see the project's growth again.